### PR TITLE
KSCU-39, KSCU-40, KSCU-11, KSCU-10, KSCU-4, KSCU-3: clean-up & condit…

### DIFF
--- a/cartridges/int_klaviyo/cartridge/templates/default/klaviyo/klaviyoFooter.isml
+++ b/cartridges/int_klaviyo/cartridge/templates/default/klaviyo/klaviyoFooter.isml
@@ -26,7 +26,7 @@
     <isif condition="${pdict.klid}">
         <isinclude template="klaviyo/klaviyoID" />
     </isif>
-    <isif condition="${dw.system.Site.getCurrent().getCustomPreferenceValue('klaviyo_email_selectors')}">
+    <isif condition="${dw.system.Site.getCurrent().getCustomPreferenceValue('klaviyo_email_selectors') && !empty(dw.system.Site.getCurrent().getCustomPreferenceValue('klaviyo_email_selectors'))}">
         <isinclude template="klaviyo/klaviyoListeners" />
     </isif>
 </isif>

--- a/cartridges/int_klaviyo_core/cartridge/templates/default/klaviyo/klaviyoListeners.isml
+++ b/cartridges/int_klaviyo_core/cartridge/templates/default/klaviyo/klaviyoListeners.isml
@@ -1,5 +1,5 @@
 <iscomment>
-    The JS in this template captures the selectors set in Business Manager and applies klaviyo to the correspondingiing input fields
+    The JS in this template captures the selectors set in Business Manager and applies klaviyo listeners to the corresponding input fields
     so users can be identified when filling out either phone number or email fields within any part of the site. This template is included in
     klaviyoFooter.isml within both SFRA & SiteGen.
 </iscomment>

--- a/cartridges/int_klaviyo_sfra/cartridge/templates/default/klaviyo/klaviyoFooter.isml
+++ b/cartridges/int_klaviyo_sfra/cartridge/templates/default/klaviyo/klaviyoFooter.isml
@@ -32,7 +32,7 @@
     <isif condition="${pdict.klid}">
         <isinclude template="klaviyo/klaviyoID" />
     </isif>
-    <isif condition="${dw.system.Site.getCurrent().getCustomPreferenceValue('klaviyo_email_selectors')}">
+    <isif condition="${dw.system.Site.getCurrent().getCustomPreferenceValue('klaviyo_email_selectors') && !empty(dw.system.Site.getCurrent().getCustomPreferenceValue('klaviyo_email_selectors'))}">
         <isinclude template="klaviyo/klaviyoListeners" />
     </isif>
 </isif>

--- a/site_template/common/meta/custom-preference_KSCU-39.xml
+++ b/site_template/common/meta/custom-preference_KSCU-39.xml
@@ -44,7 +44,6 @@
                 <type>set-of-string</type>
                 <mandatory-flag>false</mandatory-flag>
                 <externally-managed-flag>false</externally-managed-flag>
-                <default-value>large</default-value>
             </attribute-definition>
 
         </custom-attribute-definitions>


### PR DESCRIPTION
## Description

This update handles light cleanup and a conditional adjustment needed to render the klaviyoListners.isml template listeners only when needed _(ex: does not render when the BM field is empty)_. This is a follow-up to an earlier PR for the same branch [available here](https://github.com/maze-consulting/SFCC_Klaviyo_Maze/pull/4). 

## Manual Testing Steps

- This minor adjustment was tested by deleting all selectors from the site preference and confirming we see the template only IF selectors have been configured (ex: fixes issue with template rendering when the field is empty).  
- Inspecting the DOM after entering CSS selectors into the 'klaviyo_email_selectors' Site Preference in BM to confirm targeted inputs received applied attributes (ex: data-listener="klaviyo")
- Confirming maintained functionality with data creating new profiles when valid emails and/or phone numbers were provided in selected input fields. 

