### PR TITLE
KSCU-54: SiteGen Dynamic Selectors

### DIFF
--- a/cartridges/int_klaviyo_core/cartridge/templates/default/klaviyo/klaviyoListeners.isml
+++ b/cartridges/int_klaviyo_core/cartridge/templates/default/klaviyo/klaviyoListeners.isml
@@ -48,11 +48,12 @@
             for (let i = 0; i < klaviyoJS.emailFieldSelectors.length; i++) {
                 let selectedInput = document.querySelectorAll(klaviyoJS.emailFieldSelectors[i]);
                 if (selectedInput) {
-                    let klavInput = selectedInput[0];
-                    if (klavInput && !klavInput.hasAttribute('data-listener')) {
-                        klavInput.setAttribute('data-listener', 'klaviyo');
-                        klavInput.addEventListener("change", (klavInput) => klaviyoChangeEvent(klavInput));
-                    }
+                    Array.from(selectedInput).forEach(klavInput => {
+                        if (klavInput && !klavInput.hasAttribute('data-listener')) {
+                            klavInput.setAttribute('data-listener', 'klaviyo');
+                            klavInput.addEventListener("change", (klavInput) => klaviyoChangeEvent(klavInput));
+                        }
+                    })
                 }
             }
         }

--- a/cartridges/int_klaviyo_core/cartridge/templates/default/klaviyo/klaviyoListeners.isml
+++ b/cartridges/int_klaviyo_core/cartridge/templates/default/klaviyo/klaviyoListeners.isml
@@ -20,6 +20,14 @@
                 klaviyo.identify({ '$phone_number' : formattedPhone }).then(() => { klaviyoJS.identifiedUser = true; klaviyoJS.exchangeID = klaviyoJS.getExchangeID(); klaviyoJS.phone = formattedPhone; });
             }
         };
+        klaviyoJS.phoneOrEmail = function(inputVal) {
+            if (klaviyoJS.sfccEmailRegex.test (inputVal.target.value)) {
+                klaviyo.identify({ '$email' : inputVal.target.value }).then(() => { klaviyoJS.identifiedUser = true; klaviyoJS.exchangeID = klaviyoJS.getExchangeID(); });
+            }
+            if (Number(inputVal.target.value.replace(/[^a-z0-9]/gi, ''))) {
+                klaviyoJS.identifyPhone(inputVal.target.value);
+            }
+        };
         Promise.resolve(klaviyo.isIdentified()).then((result) => { klaviyoJS.identifiedUser = result });
 
         window.addEventListener('DOMContentLoaded', (event) => {
@@ -38,57 +46,33 @@
 
         function klaviyoListeners() {
             for (let i = 0; i < klaviyoJS.emailFieldSelectors.length; i++) {
-                let selectedInput;
-                if ($(klaviyoJS.emailFieldSelectors[i])[0]) {
-                    selectedInput = $(klaviyoJS.emailFieldSelectors[i]);
-                } else {
-                    let selector;
-                    if (klaviyoJS.emailFieldSelectors[i][0] === '#') {
-                        selector = 'input[id*="' + klaviyoJS.emailFieldSelectors[i].substring(1) + '"]'
-                    } else if (klaviyoJS.emailFieldSelectors[i][0] === '.') {
-                        selector = 'input[class*="' + klaviyoJS.emailFieldSelectors[i].substring(1) + '"]'
-                    }
-                    selectedInput = $(selector);
-                }
-
+                let selectedInput = document.querySelectorAll(klaviyoJS.emailFieldSelectors[i]);
                 if (selectedInput) {
                     let klavInput = selectedInput[0];
                     if (klavInput && !klavInput.hasAttribute('data-listener')) {
-                        selectedInput.attr("data-listener", 'klaviyo');  // Add this attribute as flag in DOM where listeners were applied & limit duplicate listeners on elems
-                        selectedInput.change(function(){
-                        if (klavInput.pattern && klavInput.value.match(klavInput.pattern)) {
-                            if (!klaviyoJS.identifiedUser) {
-                                if (klaviyoJS.sfccEmailRegex.test (klavInput.value)) {
-                                    klaviyo.identify({ '$email' : klavInput.value }).then(() => { klaviyoJS.identifiedUser = true; klaviyoJS.exchangeID = klaviyoJS.getExchangeID(); });
-                                }
-
-                                if (Number(klavInput.value.replace(/[^a-z0-9]/gi, ''))) {
-                                    klaviyoJS.identifyPhone(klavInput.value);
-                                }
-                            }
-                            if (klaviyoJS.identifiedUser && klaviyoJS.exchangeID && klaviyoJS.phone) {
-                                klaviyo.identify({ '$email' : klavInput.value, '$phone_number' : klaviyoJS.phone }).then(() => { klaviyoJS.identifiedUser = true; klaviyoJS.exchangeID = klaviyoJS.getExchangeID(); });
-                            }
-                        } else {
-                            if (!klaviyoJS.identifiedUser) {
-                                if (klaviyoJS.sfccEmailRegex.test (klavInput.value)) {
-                                    klaviyo.identify({ '$email' : klavInput.value }).then(() => { klaviyoJS.identifiedUser = true; klaviyoJS.exchangeID = klaviyoJS.getExchangeID(); });
-                                }
-
-                                if (Number(klavInput.value.replace(/[^a-z0-9]/gi, ''))) {
-                                    klaviyoJS.identifyPhone(klavInput.value);
-                                }
-                            }
-                            if (klaviyoJS.identifiedUser && klaviyoJS.exchangeID && klaviyoJS.phone && klaviyoJS.sfccEmailRegex.test (klavInput.value)) {
-                                klaviyo.identify({ '$email' : klavInput.value, '$phone_number' : klaviyoJS.phone }).then(() => { klaviyoJS.identifiedUser = true; klaviyoJS.exchangeID = klaviyoJS.getExchangeID(); });
-                            }
-                        }
-                        console.log(' >>>> klaviyoJS OBJ AFTER CHANGE >>>> ', klaviyoJS);  // TODO: debugging only, remove this console.log()
-                        });
+                        klavInput.setAttribute('data-listener', 'klaviyo');
+                        klavInput.addEventListener("change", (klavInput) => klaviyoChangeEvent(klavInput));
                     }
                 }
             }
         }
+
+        function klaviyoChangeEvent(input){
+            if (!klaviyoJS.identifiedUser) {
+                klaviyoJS.phoneOrEmail(input);
+            }
+            if (input.target.pattern.length && input.target.value.match(input.target.pattern)) {
+                if (klaviyoJS.identifiedUser && klaviyoJS.exchangeID && klaviyoJS.phone) {
+                    klaviyo.identify({ '$email' : input.target.value, '$phone_number' : klaviyoJS.phone }).then(() => { klaviyoJS.identifiedUser = true; klaviyoJS.exchangeID = klaviyoJS.getExchangeID(); });
+                }
+            } else {
+                if (klaviyoJS.identifiedUser && klaviyoJS.exchangeID && klaviyoJS.phone && klaviyoJS.sfccEmailRegex.test (input.target.value)) {
+                    klaviyo.identify({ '$email' : input.target.value, '$phone_number' : klaviyoJS.phone }).then(() => { klaviyoJS.identifiedUser = true; klaviyoJS.exchangeID = klaviyoJS.getExchangeID(); });
+                }
+            }
+            console.log(' >>>> klaviyoJS OBJ AFTER CHANGE >>>> ', klaviyoJS);  // TODO: debugging only, remove this console.log()
+        }
+
         klaviyoListeners();
     </script>
 

--- a/cartridges/int_klaviyo_core/cartridge/templates/default/klaviyo/klaviyoListeners.isml
+++ b/cartridges/int_klaviyo_core/cartridge/templates/default/klaviyo/klaviyoListeners.isml
@@ -38,7 +38,19 @@
 
         function klaviyoListeners() {
             for (let i = 0; i < klaviyoJS.emailFieldSelectors.length; i++) {
-                let selectedInput = $(klaviyoJS.emailFieldSelectors[i]);
+                let selectedInput;
+                if ($(klaviyoJS.emailFieldSelectors[i])[0]) {
+                    selectedInput = $(klaviyoJS.emailFieldSelectors[i]);
+                } else {
+                    let selector;
+                    if (klaviyoJS.emailFieldSelectors[i][0] === '#') {
+                        selector = 'input[id*="' + klaviyoJS.emailFieldSelectors[i].substring(1) + '"]'
+                    } else if (klaviyoJS.emailFieldSelectors[i][0] === '.') {
+                        selector = 'input[class*="' + klaviyoJS.emailFieldSelectors[i].substring(1) + '"]'
+                    }
+                    selectedInput = $(selector);
+                }
+
                 if (selectedInput) {
                     let klavInput = selectedInput[0];
                     if (klavInput && !klavInput.hasAttribute('data-listener')) {

--- a/cartridges/int_klaviyo_core/cartridge/templates/default/klaviyo/klaviyoListeners.isml
+++ b/cartridges/int_klaviyo_core/cartridge/templates/default/klaviyo/klaviyoListeners.isml
@@ -70,7 +70,6 @@
                     klaviyo.identify({ '$email' : input.target.value, '$phone_number' : klaviyoJS.phone }).then(() => { klaviyoJS.identifiedUser = true; klaviyoJS.exchangeID = klaviyoJS.getExchangeID(); });
                 }
             }
-            console.log(' >>>> klaviyoJS OBJ AFTER CHANGE >>>> ', klaviyoJS);  // TODO: debugging only, remove this console.log()
         }
 
         klaviyoListeners();

--- a/cartridges/int_klaviyo_sfra/cartridge/templates/default/klaviyo/klaviyoFooter.isml
+++ b/cartridges/int_klaviyo_sfra/cartridge/templates/default/klaviyo/klaviyoFooter.isml
@@ -9,7 +9,6 @@
 <!--- TEMPLATENAME: klaviyoFooter.isml --->
 <isif condition="${klaviyoUtils.klaviyoEnabled}">
     <script async src="//static.klaviyo.com/onsite/js/klaviyo.js?company_id=${dw.system.Site.getCurrent().preferences.custom.klaviyo_account}"></script>
-    <script src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
     <script>
         // klaviyo object loader - provided by klaviyo
         !function(){if(!window.klaviyo){window._klOnsite=window._klOnsite||[];try{window.klaviyo=new Proxy({},{get:function(n,i){return"push"===i?function(){var n;(n=window._klOnsite).push.apply(n,arguments)}:function(){for(var n=arguments.length,o=new Array(n),w=0;w<n;w++)o[w]=arguments[w];var t="function"==typeof o[o.length-1]?o.pop():void 0,e=new Promise((function(n){window._klOnsite.push([i].concat(o,[function(i){t&&t(i),n(i)}]))}));return e}}})}catch(n){window.klaviyo=window.klaviyo||[],window.klaviyo.push=function(){var n;(n=window._klOnsite).push.apply(n,arguments)}}}}();


### PR DESCRIPTION
## Description

This update addresses an issue discovered while testing email extraction in SiteGen. Previous updates from KSCU-39 _([here](https://github.com/maze-consulting/SFCC_Klaviyo_Maze/pull/4) and [here](https://github.com/maze-consulting/SFCC_Klaviyo_Maze/pull/6))_ applied data-listeners on all targeted inputs on any pages in SFRA & SiteGen sites. However inputs with specific SiteGen dynamic IDs lost listeners on page refresh because the IDs were updated to new values.

This logic adjustment addresses dynamic IDs by giving flexibility for users to use partial IDs or class names to account for dynamically created IDs and / or classnames when necessary. With this update, Klaviyo data-listeners now attach to targeted inputs with the dynamic IDs / classnames and static IDs / classnames. 


## Manual Testing Steps

This adjustment was tested across SiteGen and SFRA and checked on different browsers _(i.e. Chrome, Firefox, Safari)_ to ensure consistency. Manual testing included:

- Configuring BM site pref settings with partial input IDs for specific selectors and inspecting the DOM to confirm klaviyo data-listeners were applied. 
- Clearing cookies and confirming new profiles were created / reflected in the Klaviyo Dashboard from inputs with dynamic IDs.
- Confirming configurations with specific IDs / class names for inputs with static values received klaviyo data-listeners as expected with previously established functionality.


## Pre-Submission Checklist:

- [ x ] This update successfully builds
- [ x ] No console errors are displayed on the screen with these updates
- [ x ] No server-side errors / DW with ease issues are displayed with these updates
- [ x ] Console Logs created during development for debugging that are no longer needed have been removed
- [ n/a ] ToDo comments were left as necessary for future reference
- [ x ] A description of this update & references to the manual tests has been included in this PR