### PR TITLE
Feature/KSCU-63: Edge cases - product bundles

### DIFF
--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
@@ -75,6 +75,10 @@ function getData(basket) {
                     currentLineItem.productOptions = selectedOptions;
                 }
 
+                if (lineItem.bundledProductLineItem || lineItem.bundledProductLineItems.length) {
+                    klaviyoUtils.captureProductBundles(currentLineItem, lineItem.bundledProductLineItems);
+                }
+
                 data.lineItems.push(currentLineItem);
                 data.items.push(basketProduct.name);
                 data.categories.push.apply(

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
@@ -36,7 +36,7 @@ function getData(basket) {
             }
 
             if (currentProductID != null && !empty(basketProduct) && basketProduct.getPriceModel().getPrice().value > 0) {
-                var primaryCategory;
+                var primaryCategory, selectedOptions;
                 if (basketProduct.variant) {
                     primaryCategory = basketProduct.masterProduct.getPrimaryCategory().displayName;
                 } else {
@@ -53,7 +53,7 @@ function getData(basket) {
                     categories.push(catProduct.categoryAssignments[i].category.displayName);
                 }
 
-                data.lineItems.push({
+                var currentLineItem = {
                     productID       : currentProductID,
                     productName     : basketProduct.name,
                     productImageURL : imageSizeOfProduct,
@@ -67,8 +67,15 @@ function getData(basket) {
                     productUPC                : basketProduct.UPC,
                     viewedProductAvailability : basketProduct.availabilityModel.availability,
                     categories                : categories, // was createCategories(basketProduct) in orig, check that my output from categories above matches expected output
-                    primaryCategory           : primaryCategory
-                });
+                    primaryCategory           : primaryCategory,
+                };
+
+                selectedOptions = lineItem && lineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(lineItem.optionProductLineItems) : null;
+                if (selectedOptions && selectedOptions.length) {
+                    currentLineItem.productOptions = selectedOptions;
+                }
+
+                data.lineItems.push(currentLineItem);
                 data.items.push(basketProduct.name);
                 data.categories.push.apply(
                     data.categories,

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
@@ -141,7 +141,7 @@ function getData(order) {
 
                 var selectedOptions = productLineItem && productLineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(productLineItem.optionProductLineItems) : null;
                 if (selectedOptions && selectedOptions.length) {
-                    currentLineItem.productOptions = selectedOptions;
+                    currentLineItem['Product Options'] = selectedOptions;
                 }
 
                 productLineItemsArray.push(currentLineItem);

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
@@ -144,6 +144,10 @@ function getData(order) {
                     currentLineItem['Product Options'] = selectedOptions;
                 }
 
+                if (productLineItem.bundledProductLineItem || productLineItem.bundledProductLineItems.length) {
+                    klaviyoUtils.captureProductBundles(currentLineItem, productLineItem.bundledProductLineItems);
+                }
+
                 productLineItemsArray.push(currentLineItem);
             }
 

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
@@ -125,7 +125,7 @@ function getData(order) {
                     allCategories = productDetail.getAllCategories();
                 }
 
-                productLineItemsArray.push({
+                var currentLineItem = {
                     'Product ID'             : productLineItem.productID,
                     'Product Name'           : productLineItem.productName,
                     'Product Secondary Name' : secondaryName,
@@ -137,7 +137,14 @@ function getData(order) {
                     'Product Variant'        : variationValues,
                     'Price Value'            : productLineItem.price.value,
                     'Product Image URL'      : KLImageSize ? productDetail.getImage(KLImageSize).getAbsURL().toString() : null
-                });
+                };
+
+                var selectedOptions = productLineItem && productLineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(productLineItem.optionProductLineItems) : null;
+                if (selectedOptions && selectedOptions.length) {
+                    currentLineItem.productOptions = selectedOptions;
+                }
+
+                productLineItemsArray.push(currentLineItem);
             }
 
             // Append gift card

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
@@ -35,16 +35,14 @@ function getData(currentBasket) {
                 throw new Error('Product with ID [' + currentProductID + '] not found');
             }
             var quantity = lineItem.quantityValue;
-            var options = [];
-            if (lineItem && lineItem.optionProductLineItems) {
-                for (let i = 0; i < lineItem.optionProductLineItems.length; i++){
-                    let currOption = lineItem.optionProductLineItems[i];
-                    options.push({optionID: lineItem.optionProductLineItems[i].optionID, optionValueID: lineItem.optionProductLineItems[i].optionValueID, lineItemText: lineItem.optionProductLineItems[i].lineItemText})
-                }
-            }
+            var options = lineItem && lineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(lineItem.optionProductLineItems) : null;
 
             if (currentProductID != null && !empty(basketProduct) && basketProduct.getPriceModel().getPrice().value > 0) {
                 var productObj = prepareProductObj( lineItem, basketProduct, currentProductID );
+
+                if (options && options.length) {
+                    productObj['Product Options'] = options;
+                }
 
                 // add top-level data for the event for segmenting, etc.
                 data.line_items.push(productObj);

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
@@ -44,6 +44,10 @@ function getData(currentBasket) {
                     productObj['Product Options'] = options;
                 }
 
+                if (lineItem.bundledProductLineItem || lineItem.bundledProductLineItems.length) {
+                    klaviyoUtils.captureProductBundles(productObj, lineItem.bundledProductLineItems);
+                }
+
                 // add top-level data for the event for segmenting, etc.
                 data.line_items.push(productObj);
                 data.Categories.push.apply(data.Categories, data.line_items[itemIndex].Categories);

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -86,6 +86,17 @@ function captureProductOptions(prodOptions) {
     return selectedOptions;
 }
 
+// helper function to extract child products from product bundles & set appropriate properties on dataObjs.
+// Used in three key tracked events: 'Added to Cart', 'Started Checkout' and 'Order Confirmation.
+function captureProductBundles(basketObj, bundledProducts) {
+    basketObj['Bundled Product IDs'] = [];
+    basketObj['Is Product Bundle'] = true;
+    for (let i = 0; i < bundledProducts.length; i++) {
+        var childObj = bundledProducts[i];
+        basketObj['Bundled Product IDs'].push(childObj.productID);
+    }
+}
+
 
 function trackEvent(exchangeID, data, event) {
 
@@ -152,5 +163,6 @@ module.exports = {
     prepareDebugData : prepareDebugData,
     dedupeArray: dedupeArray,
     captureProductOptions : captureProductOptions,
+    captureProductBundles : captureProductBundles,
     trackEvent : trackEvent
 }

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -73,6 +73,20 @@ function dedupeArray(items) {
 }
 
 
+// helper function to extract product options and return each selected option into an object with three keys: lineItemText, optionId and selectedValueId.
+// This helper accomodates products that may have been configured with or feature multiple options by returning an array of each selected product option as its own optionObj.
+function captureProductOptions(prodOptions) {
+    var options = Array.isArray(prodOptions) ? prodOptions : Array.from(prodOptions);
+    var selectedOptions = [];
+
+    options.forEach(optionObj => {
+        selectedOptions.push({ lineItemText: optionObj.lineItemText, optionID: optionObj.optionID, optionValueID: optionObj.optionValueID});
+    })
+
+    return selectedOptions;
+}
+
+
 function trackEvent(exchangeID, data, event) {
 
     var requestBody = {};
@@ -129,7 +143,6 @@ function trackEvent(exchangeID, data, event) {
 
 
 
-
 module.exports = {
     EVENT_NAMES : EVENT_NAMES,
     klaviyoEnabled : klaviyoEnabled,
@@ -138,5 +151,6 @@ module.exports = {
     getProfileInfo : getProfileInfo,
     prepareDebugData : prepareDebugData,
     dedupeArray: dedupeArray,
+    captureProductOptions : captureProductOptions,
     trackEvent : trackEvent
 }


### PR DESCRIPTION
## Description

This adjustment updates the dataObj and eventData to include product bundles in three key events: _'Added to Cart'_, _'Started Checkout'_ and _'Order Confirmation'_. With this adjustment, an array containing product IDs of a product bundle's child products as well as a flag identifying product bundles in the data object now displays in the event data to provide additional metrics for merchandisers using Klaviyo. 

A need for this change was discovered while evaluating edge cases outlined in [KSCU-56](https://themazegroup.atlassian.net/browse/KSCU-56) _([KSCU-63](https://themazegroup.atlassian.net/browse/KSCU-63) is a subtask of kscu-56)_

## Manual Testing Steps

This was checked in both SFRA & SiteGen in the following ways as part of manual testing:

- Adding products bundles & proceeding through checkout / order confirmation to review data
- Adding & purchasing a product bundle & a standard product without options _(confirm. expected data in returned objs &  klaviyo dashboard for each event)_
- Adding & purchasing a mix of products with & without product options...clothing, electronics with product options, bundles with product options, etc. _(confirm. expected data in returned objs &  klaviyo dashboard for each event)_
- Confirming cart rebuilding links completed for earlier work continue to work as expected for SiteGen & SFRA _(ex: successfully creates a link that can be used to recreate a cart)_


## Pre-Submission Checklist:
[ x ] This update successfully builds
[ x ] No console errors are displayed on the screen with these updates
[ x ] Console Logs & debugging comments created during development that are no longer needed have been removed
[ n/a ] ToDo comments were left as necessary for future reference
[ x ] A description of this update & references to the manual tests has been included in this PR


## Reviewer Note:
This branch was created off the [edge case branch for KSCU-65](https://github.com/maze-consulting/SFCC_Klaviyo_Maze/tree/feature/KSCU-65_edge-cases__product-options). The [PR for KSCU-65](https://github.com/maze-consulting/SFCC_Klaviyo_Maze/pull/24) should be merged **_BEFORE_** this PR is merged. The changes in this branch when pointed to develop_maze, should mostly consist of [this commit](https://github.com/maze-consulting/SFCC_Klaviyo_Maze/commit/24294b84daa293e098488fe356b06d8afa6f2169) _(specific to this branch and separate from kscu-65)_. 
