### PR TITLE
Feature/KSCU-58: Edge cases - bonus products (kscu-58), promotions (kscu-59), discounts (kscu-60)

### DIFF
--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
@@ -58,17 +58,19 @@ function getData(basket) {
                     productName     : basketProduct.name,
                     productImageURL : imageSizeOfProduct,
                     productPageURL  : URLUtils.https('Product-Show', 'pid', currentProductID).toString(),
-                    price: dw.util.StringUtils.formatMoney(
-                        dw.value.Money(
-                            basketProduct.getPriceModel().getPrice().value,
-                            session.getCurrency().getCurrencyCode()
-                        )
-                    ),
+                    // price: dw.util.StringUtils.formatMoney(
+                    //     dw.value.Money(
+                    //         basketProduct.getPriceModel().getPrice().value,
+                    //         session.getCurrency().getCurrencyCode()
+                    //     )
+                    // ),
                     productUPC                : basketProduct.UPC,
                     viewedProductAvailability : basketProduct.availabilityModel.availability,
                     categories                : categories, // was createCategories(basketProduct) in orig, check that my output from categories above matches expected output
                     primaryCategory           : primaryCategory,
                 };
+
+                klaviyoUtils.priceCheck(lineItem, basketProduct, currentLineItem);
 
                 selectedOptions = lineItem && lineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(lineItem.optionProductLineItems) : null;
                 if (selectedOptions && selectedOptions.length) {

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
@@ -64,14 +64,21 @@ function getData(basket) {
                     primaryCategory           : primaryCategory
                 };
 
-                klaviyoUtils.priceCheck(lineItem, basketProduct, currentLineItem);
+                var priceData = klaviyoUtils.priceCheck(lineItem, basketProduct);
+                currentLineItem.Price = priceData.purchasePrice
+                if (priceData.originalPrice) {
+                    currentLineItem.originalPrice = priceData.originalPrice
+                }
+
                 selectedOptions = lineItem && lineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(lineItem.optionProductLineItems) : null;
                 if (selectedOptions && selectedOptions.length) {
                     currentLineItem.productOptions = selectedOptions;
                 }
 
                 if (lineItem.bundledProductLineItem || lineItem.bundledProductLineItems.length) {
-                    klaviyoUtils.captureProductBundles(currentLineItem, lineItem.bundledProductLineItems);
+                    var prodBundle = klaviyoUtils.captureProductBundles(lineItem.bundledProductLineItems);
+                    currentLineItem['Is Product Bundle'] = prodBundle.isProdBundle;
+                    currentLineItem['Bundled Product IDs'] = prodBundle.prodBundleIDs;
                 }
 
                 data.lineItems.push(currentLineItem);

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
@@ -75,6 +75,10 @@ function getData(basket) {
                     currentLineItem.productOptions = selectedOptions;
                 }
 
+                if (lineItem.bundledProductLineItem || lineItem.bundledProductLineItems.length) {
+                    klaviyoUtils.captureProductBundles(currentLineItem, lineItem.bundledProductLineItems);
+                }
+
                 data.lineItems.push(currentLineItem);
                 data.items.push(basketProduct.name);
                 data.categories.push.apply(

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
@@ -61,7 +61,7 @@ function getData(basket) {
                     productUPC                : basketProduct.UPC,
                     viewedProductAvailability : basketProduct.availabilityModel.availability,
                     categories                : categories, // was createCategories(basketProduct) in orig, check that my output from categories above matches expected output
-                    primaryCategory           : primaryCategory,
+                    primaryCategory           : primaryCategory
                 };
 
                 klaviyoUtils.priceCheck(lineItem, basketProduct, currentLineItem);

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
@@ -58,12 +58,6 @@ function getData(basket) {
                     productName     : basketProduct.name,
                     productImageURL : imageSizeOfProduct,
                     productPageURL  : URLUtils.https('Product-Show', 'pid', currentProductID).toString(),
-                    // price: dw.util.StringUtils.formatMoney(
-                    //     dw.value.Money(
-                    //         basketProduct.getPriceModel().getPrice().value,
-                    //         session.getCurrency().getCurrencyCode()
-                    //     )
-                    // ),
                     productUPC                : basketProduct.UPC,
                     viewedProductAvailability : basketProduct.availabilityModel.availability,
                     categories                : categories, // was createCategories(basketProduct) in orig, check that my output from categories above matches expected output
@@ -71,7 +65,6 @@ function getData(basket) {
                 };
 
                 klaviyoUtils.priceCheck(lineItem, basketProduct, currentLineItem);
-
                 selectedOptions = lineItem && lineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(lineItem.optionProductLineItems) : null;
                 if (selectedOptions && selectedOptions.length) {
                     currentLineItem.productOptions = selectedOptions;

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
@@ -36,7 +36,7 @@ function getData(basket) {
             }
 
             if (currentProductID != null && !empty(basketProduct) && basketProduct.getPriceModel().getPrice().value > 0) {
-                var primaryCategory;
+                var primaryCategory, selectedOptions;
                 if (basketProduct.variant) {
                     primaryCategory = basketProduct.masterProduct.getPrimaryCategory().displayName;
                 } else {
@@ -53,7 +53,7 @@ function getData(basket) {
                     categories.push(catProduct.categoryAssignments[i].category.displayName);
                 }
 
-                data.lineItems.push({
+                var currentLineItem = {
                     productID       : currentProductID,
                     productName     : basketProduct.name,
                     productImageURL : imageSizeOfProduct,
@@ -67,8 +67,15 @@ function getData(basket) {
                     productUPC                : basketProduct.UPC,
                     viewedProductAvailability : basketProduct.availabilityModel.availability,
                     categories                : categories, // was createCategories(basketProduct) in orig, check that my output from categories above matches expected output
-                    primaryCategory           : primaryCategory
-                });
+                    primaryCategory           : primaryCategory,
+                };
+
+                selectedOptions = lineItem && lineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(lineItem.optionProductLineItems) : null;
+                if (selectedOptions && selectedOptions.length) {
+                    currentLineItem.productOptions = selectedOptions;
+                }
+
+                data.lineItems.push(currentLineItem);
                 data.items.push(basketProduct.name);
                 data.categories.push.apply(
                     data.categories,

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
@@ -141,7 +141,7 @@ function getData(order) {
 
                 var selectedOptions = productLineItem && productLineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(productLineItem.optionProductLineItems) : null;
                 if (selectedOptions && selectedOptions.length) {
-                    currentLineItem.productOptions = selectedOptions;
+                    currentLineItem['Product Options'] = selectedOptions;
                 }
 
                 productLineItemsArray.push(currentLineItem);

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
@@ -144,6 +144,10 @@ function getData(order) {
                     currentLineItem['Product Options'] = selectedOptions;
                 }
 
+                if (productLineItem.bundledProductLineItem || productLineItem.bundledProductLineItems.length) {
+                    klaviyoUtils.captureProductBundles(currentLineItem, productLineItem.bundledProductLineItems);
+                }
+
                 productLineItemsArray.push(currentLineItem);
             }
 

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
@@ -71,7 +71,6 @@ function getData(order) {
                 productLineItem = productLineItems[j];
                 var prdUrl = '';
                 var replenishment = false;
-                var priceString = '';
                 // var priceValue = 0.0;
                 // var hasOsfSmartOrderRefill = false;
                 prdUrl = URLUtils.https( 'Product-Show', 'pid', productLineItem.productID ).toString();
@@ -84,15 +83,9 @@ function getData(order) {
                     throw new Error('Product with ID [' + lineItemProduct.ID + '] not found');
                 }
 
-                if (!productLineItem.bonusProductLineItem) {
-                    priceString = dw.util.StringUtils.formatMoney( dw.value.Money( productLineItem.price.value, session.getCurrency().getCurrencyCode() ) );
-                } else {
-                    priceString = dw.util.StringUtils.formatMoney( dw.value.Money(0, session.getCurrency().getCurrencyCode()) );
-                }
-
                 // Variation values
                 var variationValues = '';
-                if (productDetail.isVariant()) { 
+                if (productDetail.isVariant()) {
                     var variationAttrs = productDetail.variationModel.getProductVariationAttributes();
                     for (var i = 0; i < variationAttrs.length; i++) {
                         var VA = variationAttrs[i];
@@ -130,7 +123,6 @@ function getData(order) {
                     'Product Name'           : productLineItem.productName,
                     'Product Secondary Name' : secondaryName,
                     'Quantity'                 : productLineItem.quantity.value,
-                    'Price'                    : priceString,
                     'Discount'                 : productLineItem.adjustedPrice.value, // TODO: this does not appear to be correct...just provides the adjusted price...but does not show a 'discounted' product value
                     'Product Page URL'       : prdUrl,
                     'Replenishment'            : replenishment,
@@ -139,6 +131,7 @@ function getData(order) {
                     'Product Image URL'      : KLImageSize ? productDetail.getImage(KLImageSize).getAbsURL().toString() : null
                 };
 
+                klaviyoUtils.priceCheck(productLineItem, productDetail, currentLineItem);
                 var selectedOptions = productLineItem && productLineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(productLineItem.optionProductLineItems) : null;
                 if (selectedOptions && selectedOptions.length) {
                     currentLineItem['Product Options'] = selectedOptions;

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
@@ -123,7 +123,7 @@ function getData(order) {
                     'Product Name'           : productLineItem.productName,
                     'Product Secondary Name' : secondaryName,
                     'Quantity'                 : productLineItem.quantity.value,
-                    'Discount'                 : productLineItem.adjustedPrice.value, // TODO: this does not appear to be correct...just provides the adjusted price...but does not show a 'discounted' product value
+                    'Discount'                 : productLineItem.adjustedPrice.value,
                     'Product Page URL'       : prdUrl,
                     'Replenishment'            : replenishment,
                     'Product Variant'        : variationValues,
@@ -131,18 +131,28 @@ function getData(order) {
                     'Product Image URL'      : KLImageSize ? productDetail.getImage(KLImageSize).getAbsURL().toString() : null
                 };
 
-                klaviyoUtils.priceCheck(productLineItem, productDetail, currentLineItem);
+                var priceData = klaviyoUtils.priceCheck(productLineItem, productDetail);
+                currentLineItem['Price'] = priceData.purchasePrice
+                if (priceData.originalPrice) {
+                    currentLineItem['Original Price'] = priceData.originalPrice
+                }
+
                 var selectedOptions = productLineItem && productLineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(productLineItem.optionProductLineItems) : null;
                 if (selectedOptions && selectedOptions.length) {
                     currentLineItem['Product Options'] = selectedOptions;
                 }
 
                 if (productLineItem.bonusProductLineItem) {
-                    klaviyoUtils.captureBonusProduct(productLineItem, productDetail, currentLineItem);
+                    var bonusProduct = klaviyoUtils.captureBonusProduct(productLineItem, productDetail);
+                    currentLineItem['Is Bonus Product'] = bonusProduct.isbonusProduct;
+                    currentLineItem['Original Price'] = bonusProduct.originalPrice;
+                    currentLineItem['Price'] = bonusProduct.price;
                 }
 
                 if (productLineItem.bundledProductLineItem || productLineItem.bundledProductLineItems.length) {
-                    klaviyoUtils.captureProductBundles(currentLineItem, productLineItem.bundledProductLineItems);
+                    var prodBundle = klaviyoUtils.captureProductBundles(productLineItem.bundledProductLineItems);
+                    currentLineItem['Is Product Bundle'] = prodBundle.isProdBundle;
+                    currentLineItem['Bundled Product IDs'] = prodBundle.prodBundleIDs;
                 }
 
                 productLineItemsArray.push(currentLineItem);

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
@@ -125,7 +125,7 @@ function getData(order) {
                     allCategories = productDetail.getAllCategories();
                 }
 
-                productLineItemsArray.push({
+                var currentLineItem = {
                     'Product ID'             : productLineItem.productID,
                     'Product Name'           : productLineItem.productName,
                     'Product Secondary Name' : secondaryName,
@@ -137,7 +137,14 @@ function getData(order) {
                     'Product Variant'        : variationValues,
                     'Price Value'            : productLineItem.price.value,
                     'Product Image URL'      : KLImageSize ? productDetail.getImage(KLImageSize).getAbsURL().toString() : null
-                });
+                };
+
+                var selectedOptions = productLineItem && productLineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(productLineItem.optionProductLineItems) : null;
+                if (selectedOptions && selectedOptions.length) {
+                    currentLineItem.productOptions = selectedOptions;
+                }
+
+                productLineItemsArray.push(currentLineItem);
             }
 
             // Append gift card

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
@@ -131,7 +131,7 @@ function getData(order) {
                     'Product Secondary Name' : secondaryName,
                     'Quantity'                 : productLineItem.quantity.value,
                     'Price'                    : priceString,
-                    'Discount'                 : productLineItem.adjustedPrice.value,
+                    'Discount'                 : productLineItem.adjustedPrice.value, // TODO: this does not appear to be correct...just provides the adjusted price...but does not show a 'discounted' product value
                     'Product Page URL'       : prdUrl,
                     'Replenishment'            : replenishment,
                     'Product Variant'        : variationValues,
@@ -142,6 +142,10 @@ function getData(order) {
                 var selectedOptions = productLineItem && productLineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(productLineItem.optionProductLineItems) : null;
                 if (selectedOptions && selectedOptions.length) {
                     currentLineItem['Product Options'] = selectedOptions;
+                }
+
+                if (productLineItem.bonusProductLineItem) {
+                    klaviyoUtils.captureBonusProduct(productLineItem, productDetail, currentLineItem);
                 }
 
                 if (productLineItem.bundledProductLineItem || productLineItem.bundledProductLineItems.length) {

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
@@ -45,7 +45,9 @@ function getData(currentBasket) {
                 }
 
                 if (lineItem.bundledProductLineItem || lineItem.bundledProductLineItems.length) {
-                    klaviyoUtils.captureProductBundles(productObj, lineItem.bundledProductLineItems);
+                    var prodBundle = klaviyoUtils.captureProductBundles(lineItem.bundledProductLineItems);
+                    productObj['Is Product Bundle'] = prodBundle.isProdBundle;
+                    productObj['Bundled Product IDs'] = prodBundle.prodBundleIDs;
                 }
 
                 // add top-level data for the event for segmenting, etc.
@@ -74,9 +76,16 @@ function getData(currentBasket) {
 function prepareProductObj(lineItem, basketProduct, currentProductID) {
     var productObj = {};
     if (lineItem.bonusProductLineItem) {
-        klaviyoUtils.captureBonusProduct(lineItem, basketProduct, productObj);
+        var bonusProduct = klaviyoUtils.captureBonusProduct(lineItem, basketProduct);
+        productObj['Is Bonus Product'] = bonusProduct.isbonusProduct;
+        productObj['Original Price'] = bonusProduct.originalPrice;
+        productObj['Price'] = bonusProduct.price;
     } else {
-        klaviyoUtils.priceCheck(lineItem, basketProduct, productObj);
+        var lineItemPriceData = klaviyoUtils.priceCheck(lineItem, basketProduct);
+        productObj['Price'] = lineItemPriceData.purchasePrice
+        if (lineItemPriceData.originalPrice) {
+            productObj['Original Price'] = lineItemPriceData.originalPrice
+        }
     }
     productObj['Product ID'] = currentProductID;
     productObj['Product Name'] = basketProduct.name;

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
@@ -35,16 +35,14 @@ function getData(currentBasket) {
                 throw new Error('Product with ID [' + currentProductID + '] not found');
             }
             var quantity = lineItem.quantityValue;
-            var options = [];
-            if (lineItem && lineItem.optionProductLineItems) {
-                for (let i = 0; i < lineItem.optionProductLineItems.length; i++){
-                    let currOption = lineItem.optionProductLineItems[i];
-                    options.push({optionID: lineItem.optionProductLineItems[i].optionID, optionValueID: lineItem.optionProductLineItems[i].optionValueID, lineItemText: lineItem.optionProductLineItems[i].lineItemText})
-                }
-            }
+            var options = lineItem && lineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(lineItem.optionProductLineItems) : null;
 
             if (currentProductID != null && !empty(basketProduct) && basketProduct.getPriceModel().getPrice().value > 0) {
                 var productObj = prepareProductObj( lineItem, basketProduct, currentProductID );
+
+                if (options && options.length) {
+                    productObj['Product Options'] = options;
+                }
 
                 // add top-level data for the event for segmenting, etc.
                 data.line_items.push(productObj);

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
@@ -70,10 +70,14 @@ function getData(currentBasket) {
 // TODO: this is called in one location... can it just be inlined?
 function prepareProductObj(lineItem, basketProduct, currentProductID) {
     var productObj = {};
+    if (lineItem.bonusProductLineItem) {
+        klaviyoUtils.captureBonusProduct(lineItem, basketProduct, productObj);
+    } else {
+        productObj.Price = dw.util.StringUtils.formatMoney( dw.value.Money( basketProduct.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode() ) );
+    }
     productObj['Product ID'] = currentProductID;
     productObj['Product Name'] = basketProduct.name;
     productObj['Product Image URL'] = KLImageSize ? basketProduct.getImage(KLImageSize).getAbsURL().toString() : null;
-    productObj.Price = dw.util.StringUtils.formatMoney( dw.value.Money( basketProduct.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode() ) );
     productObj['Product Description'] = basketProduct.pageDescription ? basketProduct.pageDescription.toString() : null;
     productObj['Product Page URL'] = URLUtils.https('Product-Show', 'pid', currentProductID).toString();
     productObj['Product UPC'] = basketProduct.UPC;

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
@@ -54,7 +54,10 @@ function getData(currentBasket) {
                 data.Categories = klaviyoUtils.dedupeArray(data.Categories);
                 data.Items.push(data.line_items[itemIndex]['Product Name']);
 
-                reconstructCartItems.push({ productID: currentProductID, quantity: quantity, options: options });
+                // Exclude bonus products from reconstructCartItems array (Note: This excludes bonus products from being included in the cart rebuilding link))
+                if (!lineItem.bonusProductLineItem) {
+                    reconstructCartItems.push({ productID: currentProductID, quantity: quantity, options: options });
+                }
             }
         }
 

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
@@ -73,7 +73,7 @@ function prepareProductObj(lineItem, basketProduct, currentProductID) {
     if (lineItem.bonusProductLineItem) {
         klaviyoUtils.captureBonusProduct(lineItem, basketProduct, productObj);
     } else {
-        productObj.Price = dw.util.StringUtils.formatMoney( dw.value.Money( basketProduct.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode() ) );
+        klaviyoUtils.priceCheck(lineItem, basketProduct, productObj);
     }
     productObj['Product ID'] = currentProductID;
     productObj['Product Name'] = basketProduct.name;

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
@@ -44,6 +44,10 @@ function getData(currentBasket) {
                     productObj['Product Options'] = options;
                 }
 
+                if (lineItem.bundledProductLineItem || lineItem.bundledProductLineItems.length) {
+                    klaviyoUtils.captureProductBundles(productObj, lineItem.bundledProductLineItems);
+                }
+
                 // add top-level data for the event for segmenting, etc.
                 data.line_items.push(productObj);
                 data.Categories.push.apply(data.Categories, data.line_items[itemIndex].Categories);

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -1,11 +1,12 @@
 'use strict';
 
+/* API Includes */
 var Site = require('dw/system/Site');
 var StringUtils = require('dw/util/StringUtils');
 var Logger = require('dw/system/Logger');
 
+/* Script Modules */
 var klaviyoServices = require('*/cartridge/scripts/klaviyo/services.js');
-var priceHelper = require('*/cartridge/scripts/helpers/pricing');
 
 // event name constants
 // TODO: currently crossover with WHITELISTED_EVENTS below - square them when answers are found to why WHITELISTED_EVENTS exists
@@ -113,7 +114,7 @@ function captureBonusProduct (lineItemObj, prodObj, trackedObj) {
 // Used in order level events: 'Started Checkout' and 'Order Confirmation'.
 function priceCheck (lineItemObj, basketProdObj, trackedObj) {
     var priceModel = basketProdObj ? basketProdObj.getPriceModel() : null;
-    var priceBook = priceModel ? priceHelper.getRootPriceBook(priceModel.priceInfo.priceBook) : null;
+    var priceBook = priceModel ? _getRootPriceBook(priceModel.priceInfo.priceBook) : null;
     var priceBookPrice = priceBook && priceModel ? priceModel.getPriceBookPrice(priceBook.ID) : null;
 
     if (trackedObj) {
@@ -125,6 +126,20 @@ function priceCheck (lineItemObj, basketProdObj, trackedObj) {
             trackedObj['Price'] = basketProdObj ? StringUtils.formatMoney(dw.value.Money( basketProdObj.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode() )) : null;
         }
     }
+}
+
+
+/**
+ * Return root price book for a given price book
+ * @param {dw.catalog.PriceBook} priceBook - Provided price book
+ * @returns {dw.catalog.PriceBook} root price book
+ */
+function _getRootPriceBook(priceBook) {
+    var rootPriceBook = priceBook;
+    while (rootPriceBook.parentPriceBook) {
+        rootPriceBook = rootPriceBook.parentPriceBook;
+    }
+    return rootPriceBook;
 }
 
 

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -82,7 +82,7 @@ function captureProductOptions(prodOptions) {
     var selectedOptions = [];
 
     options.forEach(optionObj => {
-        selectedOptions.push({ lineItemText: optionObj.lineItemText, optionID: optionObj.optionID, optionValueID: optionObj.optionValueID});
+        selectedOptions.push({ lineItemText: optionObj.lineItemText, optionID: optionObj.optionID, optionValueID: optionObj.optionValueID, optionPrice: optionObj.basePrice.value });
     })
 
     return selectedOptions;

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -86,6 +86,17 @@ function captureProductOptions(prodOptions) {
     return selectedOptions;
 }
 
+// helper function to extract child products from product bundles & set appropriate properties on dataObjs.
+// Used in three key tracked events: 'Added to Cart', 'Started Checkout' and 'Order Confirmation.
+function captureProductBundles(basketObj, bundledProducts) {
+    basketObj['Bundled Product IDs'] = [];
+    basketObj['Is Product Bundle'] = true;
+    for (let i = 0; i < bundledProducts.length; i++) {
+        var childObj = bundledProducts[i];
+        basketObj['Bundled Product IDs'].push(childObj.productID);
+    }
+}
+
 
 function trackEvent(exchangeID, data, event) {
 
@@ -152,5 +163,6 @@ module.exports = {
     prepareDebugData : prepareDebugData,
     dedupeArray: dedupeArray,
     captureProductOptions : captureProductOptions,
+    captureProductBundles : captureProductBundles,
     trackEvent : trackEvent
 }

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -101,10 +101,25 @@ function captureProductBundles(basketObj, bundledProducts) {
 
 // helper function to handle bonus products & set appropriate properties on dataObjs.
 // Used in two key tracked events: 'Started Checkout' and 'Order Confirmation'.
-function captureBonusProduct (lineItem, prodObj, trackedObj) {
+function captureBonusProduct (lineItemObj, prodObj, trackedObj) {
     trackedObj['Is Bonus Product'] = true;
-    trackedObj['Original Price'] = dw.util.StringUtils.formatMoney(dw.value.Money( prodObj.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode() ));
-    trackedObj['Price'] = dw.util.StringUtils.formatMoney(dw.value.Money( lineItem.adjustedPrice.value, session.getCurrency().getCurrencyCode() ));
+    trackedObj['Original Price'] = StringUtils.formatMoney(dw.value.Money( prodObj.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode() ));
+    trackedObj['Price'] = StringUtils.formatMoney(dw.value.Money( lineItemObj.adjustedPrice.value, session.getCurrency().getCurrencyCode() ));
+}
+
+
+// helper function to consider promos & set Price and Original Pride properties on dataObjs.
+// Used in order level events: 'Started Checkout' and 'Order Confirmation'.
+function priceCheck (lineItemObj, basketProdObj, trackedObj) {
+    if (trackedObj) {
+        var adjustedPromoPrice = lineItemObj && lineItemObj.adjustedPrice < lineItemObj.basePrice ? StringUtils.formatMoney(dw.value.Money( lineItemObj.adjustedPrice.value, session.getCurrency().getCurrencyCode() )) : null;
+        if (adjustedPromoPrice) {
+            trackedObj['Price'] = StringUtils.formatMoney(dw.value.Money( lineItemObj.adjustedPrice.value, session.getCurrency().getCurrencyCode() ));
+            trackedObj['Original Price'] = StringUtils.formatMoney(dw.value.Money( basketProdObj.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode() ));
+        } else {
+            trackedObj['Price'] = basketProdObj ? StringUtils.formatMoney(dw.value.Money( basketProdObj.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode() )) : null;
+        }
+    }
 }
 
 
@@ -175,5 +190,6 @@ module.exports = {
     captureProductOptions : captureProductOptions,
     captureProductBundles : captureProductBundles,
     captureBonusProduct : captureBonusProduct,
+    priceCheck : priceCheck,
     trackEvent : trackEvent
 }

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -86,8 +86,9 @@ function captureProductOptions(prodOptions) {
     return selectedOptions;
 }
 
+
 // helper function to extract child products from product bundles & set appropriate properties on dataObjs.
-// Used in three key tracked events: 'Added to Cart', 'Started Checkout' and 'Order Confirmation.
+// Used in three key tracked events: 'Added to Cart', 'Started Checkout' and 'Order Confirmation'.
 function captureProductBundles(basketObj, bundledProducts) {
     basketObj['Bundled Product IDs'] = [];
     basketObj['Is Product Bundle'] = true;
@@ -95,6 +96,15 @@ function captureProductBundles(basketObj, bundledProducts) {
         var childObj = bundledProducts[i];
         basketObj['Bundled Product IDs'].push(childObj.productID);
     }
+}
+
+
+// helper function to handle bonus products & set appropriate properties on dataObjs.
+// Used in two key tracked events: 'Started Checkout' and 'Order Confirmation'.
+function captureBonusProduct (lineItem, prodObj, trackedObj) {
+    trackedObj['Is Bonus Product'] = true;
+    trackedObj['Original Price'] = dw.util.StringUtils.formatMoney(dw.value.Money( prodObj.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode() ));
+    trackedObj['Price'] = dw.util.StringUtils.formatMoney(dw.value.Money( lineItem.adjustedPrice.value, session.getCurrency().getCurrencyCode() ));
 }
 
 
@@ -164,5 +174,6 @@ module.exports = {
     dedupeArray: dedupeArray,
     captureProductOptions : captureProductOptions,
     captureProductBundles : captureProductBundles,
+    captureBonusProduct : captureBonusProduct,
     trackEvent : trackEvent
 }

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -73,6 +73,20 @@ function dedupeArray(items) {
 }
 
 
+// helper function to extract product options and return each selected option into an object with three keys: lineItemText, optionId and selectedValueId.
+// This helper accomodates products that may have been configured with or feature multiple options by returning an array of each selected product option as its own optionObj.
+function captureProductOptions(prodOptions) {
+    var options = Array.isArray(prodOptions) ? prodOptions : Array.from(prodOptions);
+    var selectedOptions = [];
+
+    options.forEach(optionObj => {
+        selectedOptions.push({ lineItemText: optionObj.lineItemText, optionID: optionObj.optionID, optionValueID: optionObj.optionValueID});
+    })
+
+    return selectedOptions;
+}
+
+
 function trackEvent(exchangeID, data, event) {
 
     var requestBody = {};
@@ -129,7 +143,6 @@ function trackEvent(exchangeID, data, event) {
 
 
 
-
 module.exports = {
     EVENT_NAMES : EVENT_NAMES,
     klaviyoEnabled : klaviyoEnabled,
@@ -138,5 +151,6 @@ module.exports = {
     getProfileInfo : getProfileInfo,
     prepareDebugData : prepareDebugData,
     dedupeArray: dedupeArray,
+    captureProductOptions : captureProductOptions,
     trackEvent : trackEvent
 }


### PR DESCRIPTION
## Description

This adjustment updates the `dataObj` and `eventData` to accommodate Promotions _([KSCU-59](https://themazegroup.atlassian.net/browse/KSCU-59))_, Discounts _([KSCU-60](https://themazegroup.atlassian.net/browse/KSCU-60))_ and Bonus Products _([KSCU-58](https://themazegroup.atlassian.net/browse/KSCU-58))_.  A need to make these changes was discovered while evaluating each of these, which are subtasks of the edge cases outlined in [KSCU-56](https://themazegroup.atlassian.net/browse/KSCU-56).

With these changes, original price is noted in the tracked data in their own property, promotional & discounted prices are correctly reflected as product prices in key events and bonus products now have a special flag to differentiate bonus products from other products in the _'Started Checkout'_ and _'Order Confirmation'_ events. 


## Manual Testing Steps

This was checked in both SFRA & SiteGen in the following ways as part of manual testing:

- Adding & purchasing a product with a  promotional price (confirm. expected data in returned objs & klaviyo dashboard for each event)
- Adding & purchasing a product with a discounted price (confirm. expected data in returned objs & klaviyo dashboard for each event)
- Adding & purchasing a product with bonus products (confirm. expected data in returned objs & klaviyo dashboard for each event)
- Adding & purchasing a mix of products with & without promos, discounts, bonus products, product options...clothing, electronics with product options, bundles with product options, etc. (confirm. expected data in returned objs & klaviyo dashboard for each event)
- Confirming cart rebuilding links completed for earlier work continue to work as expected for SiteGen & SFRA (ex: successfully creates a link that can be used to recreate a cart...**_which excludes any bonus products_**)

## Pre-Submission Checklist:

[ x ] This update successfully builds
[ x ] No console errors are displayed on the screen with these updates
[ x ] Console Logs & debugging comments created during development that are no longer needed have been removed
[ n/a ] ToDo comments were left as necessary for future reference
[ x ] A description of this update & references to the manual tests has been included in this PR

## Special Reviewer Note:
This branch was created off the [edge case branch for KSCU-65](https://github.com/maze-consulting/SFCC_Klaviyo_Maze/tree/feature/KSCU-65_edge-cases__product-options). The PRs for [product options](https://github.com/maze-consulting/SFCC_Klaviyo_Maze/pull/24) and [product bundles](https://github.com/maze-consulting/SFCC_Klaviyo_Maze/pull/25) should be merged **BEFORE this PR**. 
