### PR TITLE
clean-up: use klaviyoEnabled value in SiteGen controllers in place of…

### DIFF
--- a/_sitegen/controllers/Account.js
+++ b/_sitegen/controllers/Account.js
@@ -27,7 +27,7 @@ function show() {
 
     // KLAVIYO
     var klaviyoUtils = require('*/cartridge/scripts/klaviyo/utils'), klid;
-    if(dw.system.Site.getCurrent().getCustomPreferenceValue('klaviyo_enabled') && !klaviyoUtils.getKlaviyoExchangeID()){
+    if (klaviyoUtils.klaviyoEnabled && !klaviyoUtils.getKlaviyoExchangeID()){
         klid = klaviyoUtils.getProfileInfo();
     }
     // END KLAVIYO

--- a/_sitegen/controllers/COSummary.js
+++ b/_sitegen/controllers/COSummary.js
@@ -93,7 +93,7 @@ function showConfirmation(order) {
     /* Klaviyo Order Confirmation event tracking */
     var klaviyoUtils = require('*/cartridge/scripts/klaviyo/utils');
     var orderConfirmationData = require('*/cartridge/scripts/klaviyo/eventData/orderConfirmation');
-    if(dw.system.Site.getCurrent().getCustomPreferenceValue('klaviyo_enabled')){
+    if (klaviyoUtils.klaviyoEnabled){
         session.privacy.klaviyoCheckoutTracked = false;
         var exchangeID = klaviyoUtils.getKlaviyoExchangeID();
         var dataObj, serviceCallResult;

--- a/_sitegen/controllers/Cart.js
+++ b/_sitegen/controllers/Cart.js
@@ -46,7 +46,7 @@ function show() {
 
     // KLAVIYO
     var klaviyoUtils = require('*/cartridge/scripts/klaviyo/utils'), klid;
-    if(dw.system.Site.getCurrent().getCustomPreferenceValue('klaviyo_enabled') && !klaviyoUtils.getKlaviyoExchangeID()){
+    if (klaviyoUtils.klaviyoEnabled && !klaviyoUtils.getKlaviyoExchangeID()){
         klid = klaviyoUtils.getProfileInfo();
     }
     // END KLAVIYO
@@ -279,7 +279,7 @@ function addProduct() {
     var BasketMgr = require('dw/order/BasketMgr');
     var klaviyoUtils = require('*/cartridge/scripts/klaviyo/utils');
     var addedToCartData = require('*/cartridge/scripts/klaviyo/eventData/addedToCart');
-    if(dw.system.Site.getCurrent().getCustomPreferenceValue('klaviyo_enabled')){
+    if (klaviyoUtils.klaviyoEnabled){
         var exchangeID = klaviyoUtils.getKlaviyoExchangeID();
         var dataObj, serviceCallResult, currentBasket;
         var isKlDebugOn = request.getHttpReferer().includes('kldebug=true') ? true : false;

--- a/cartridges/int_klaviyo/cartridge/controllers/Klaviyo.js
+++ b/cartridges/int_klaviyo/cartridge/controllers/Klaviyo.js
@@ -25,7 +25,7 @@ var r = require("*/cartridge/scripts/util/Response");
  */
 var Event = function () {
 
-    if(dw.system.Site.getCurrent().getCustomPreferenceValue('klaviyo_enabled')){
+    if (klaviyoUtils.klaviyoEnabled){
         var kx = request.httpParameterMap.kx;
         var exchangeID = (!kx.empty) ? kx.stringValue : klaviyoUtils.getKlaviyoExchangeID();
         var isKlDebugOn = request.httpParameterMap.kldebug.booleanValue;

--- a/cartridges/int_klaviyo/cartridge/templates/default/klaviyo/klaviyoFooter.isml
+++ b/cartridges/int_klaviyo/cartridge/templates/default/klaviyo/klaviyoFooter.isml
@@ -2,7 +2,7 @@
     var klaviyoUtils = require('*/cartridge/scripts/klaviyo/utils');
 </isscript>
 <!--- TEMPLATENAME: klaviyoTag.isml --->
-<isif condition="${dw.system.Site.getCurrent().getCustomPreferenceValue('klaviyo_enabled')}">
+<isif condition="${klaviyoUtils.klaviyoEnabled}">
     <script async src="//static.klaviyo.com/onsite/js/klaviyo.js?company_id=${dw.system.Site.getCurrent().preferences.custom.klaviyo_account}"></script>
     <script>
         // klaviyo object loader - provided by klaviyo

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -73,7 +73,7 @@ function dedupeArray(items) {
 }
 
 
-// helper function to extract product options and return each selected option into an object with three keys: lineItemText, optionId and selectedValueId.
+// helper function to extract product options and return each selected option into an object with five keys: 'Line Item Text', 'Option ID' and 'Option Value ID', 'Option Price' and 'Option Price Value.
 // This helper accomodates products that may have been configured with or feature multiple options by returning an array of each selected product option as its own optionObj.
 function captureProductOptions(prodOptions) {
     var options = Array.isArray(prodOptions) ? prodOptions : Array.from(prodOptions);


### PR DESCRIPTION
## Description

This update includes an adjustment to use klaviyoEnabled in the SiteGen controllers instead of using a call to `dw.system.Site.getCurrent().getCustomPreferenceValue('klaviyo_enabled')`. It's a minor clean-up that brings SiteGen controllers in alignment with SFRA checks using the klaviyoEnabled check.

Adjustment includes on tweak to a comment related for context following other develop_maze changes. 

## Manual Testing Steps

This was tested by quickly running through events with the debugger on to see if breakpoints were hit. Dashboard checked as well during checks. 

