### PR TITLE
fix variable name typo for debugging data in Add to Cart in SiteGen.

### DIFF
--- a/_sitegen/controllers/Cart.js
+++ b/_sitegen/controllers/Cart.js
@@ -291,9 +291,9 @@ function addProduct() {
                 if (isKlDebugOn) {
                     var klDebugData = klaviyoUtils.prepareDebugData(dataObj);
                     var serviceCallData = klaviyoUtils.prepareDebugData(serviceCallResult);
-                    var siteGenKlDebutData = `<input type="hidden" name="siteGenKlDebutData" id="siteGenKlDebutData" value="${klDebugData}"/>`;
+                    var siteGenKlDebugData = `<input type="hidden" name="siteGenKlDebugData" id="siteGenKlDebugData" value="${klDebugData}"/>`;
                     var siteGenServiceCallData = `<input type="hidden" name="siteGenServiceCallData" id="siteGenServiceCallData" value="${serviceCallData}"/>`;
-                    response.writer.print(siteGenKlDebutData);
+                    response.writer.print(siteGenKlDebugData);
                     response.writer.print(siteGenServiceCallData);
                 }
             }

--- a/cartridges/int_klaviyo_core/cartridge/templates/default/klaviyo/klaviyoDebug.isml
+++ b/cartridges/int_klaviyo_core/cartridge/templates/default/klaviyo/klaviyoDebug.isml
@@ -26,7 +26,7 @@
             const observer = new MutationObserver(mutations => {
                 mutations.forEach(mutation => {
                     if (mutation.addedNodes.length) {
-                        let SGaddToCartDebugData = document.getElementById('siteGenKlDebutData');
+                        let SGaddToCartDebugData = document.getElementById('siteGenKlDebugData');
                         let SGserviceCallData = document.getElementById('siteGenServiceCallData');
                         console.log('Klaviyo Add To Cart Event Data: ', JSON.parse(atob(SGaddToCartDebugData.value)));
                         console.log('Klaviyo Add To Cart Service Result: ', JSON.parse(atob(siteGenServiceCallData.value)));


### PR DESCRIPTION
## Description

This update corrects a typo in a variable name that was used for KL Debugging mode -- The Add to Cart debugging message in SiteGen. 

## Manual Testing Steps

This was tested by activating debugging mode with add to cart with this change as well as a code-wide search for any other references to the original misspelling to confirm all uses were captured with this minor adjustment.