### PR TITLE
Removed started checkout client-side debug test

### DIFF
--- a/test/src/tests/e2e/sitegen/checkout/checkout-tests.spec.js
+++ b/test/src/tests/e2e/sitegen/checkout/checkout-tests.spec.js
@@ -27,28 +27,6 @@ test.beforeEach(async ({ page, isMobile }) => {
     await checkoutPage.acceptCookies()
 })
 
-test.describe('Test Klaviyo started checkout event not identified', () => {
-    test('Enter checkout flow as guest', async ({ page }) => {
-        // Checkout as guest so we can be identified
-        const resultMsg = 'Klaviyo Service Result:'
-        email = await checkoutPage.generateEmail()
-        testData.email = email
-        await checkoutPage.productPage.getProduct()
-        await checkoutPage.productPage.addToCart()
-        await checkoutPage.startCheckout()
-        await page.getByRole('button', { name: 'Checkout as Guest' }).click()
-        await checkoutPage.fillShippingForm(testData)
-        await checkoutPage.fillBillingForm(testData)
-        await checkoutPage.fillPaymentForm(paymentData)
-        expect(await checkoutPage.orderSuccessMessage.textContent()).toBe('Thank you for your order.')
-        await checkoutPage.productPage.getProduct()
-        await checkoutPage.productPage.addToCart()
-        await checkoutPage.startCheckout()
-        const logData = await checkoutPage.getDebugLogs(resultMsg)
-        expect(logData[0].success).toBe(true)
-    })
-})
-
 test.describe('Test Klaviyo add to cart event', () => {
     test('Verify add to cart event data', async ({ page }) => {
         const resultMsg = 'Klaviyo Service Result:'


### PR DESCRIPTION
## Description

This PR removes the started checkout client-side debug test for SiteGen due limitations on the platform

## Manual Testing Steps

1. Change into the `test` directory
2. Using node 18.16.x run `npm install`
3. Run `npx playwright test src/tests/e2e/sitegen/checkout/checkout-tests.spec.js --project="chrome desktop"`

Please see the README inside the `test` directory for details on test automation