### PR TITLE
Linter fixes

### DIFF
--- a/cartridges/int_klaviyo/cartridge/controllers/Klaviyo.js
+++ b/cartridges/int_klaviyo/cartridge/controllers/Klaviyo.js
@@ -27,7 +27,10 @@ var Event = function () {
         var kx = request.httpParameterMap.kx;
         var exchangeID = (!kx.empty) ? kx.stringValue : klaviyoUtils.getKlaviyoExchangeID();
         var isKlDebugOn = request.httpParameterMap.kldebug.booleanValue;
-        var dataObj, serviceCallResult, action, parms;
+        var dataObj;
+        var serviceCallResult;
+        var action;
+        var parms;
 
         if (exchangeID) {
             action = request.httpParameterMap.action.stringValue;

--- a/cartridges/int_klaviyo/cartridge/controllers/Klaviyo.js
+++ b/cartridges/int_klaviyo/cartridge/controllers/Klaviyo.js
@@ -19,7 +19,7 @@ var r = require("*/cartridge/scripts/util/Response");
 
 /**
  * Controller that sends the necessary data required for klaviyo to track user events
- * such as checkout, order confirmation, searching etc and renders the renders the klaviyoTag isml file
+ * such as checkout, order confirmation, searching etc and renders the renders the klaviyoFooter.isml file
  *
  * @module controllers/Klaviyo
  */

--- a/cartridges/int_klaviyo/cartridge/controllers/Klaviyo.js
+++ b/cartridges/int_klaviyo/cartridge/controllers/Klaviyo.js
@@ -1,7 +1,6 @@
 'use strict';
 
 /* API Includes */
-var ISML = require('dw/template/ISML');
 var StringUtils = require('dw/util/StringUtils');
 
 /* Script Modules */
@@ -24,8 +23,7 @@ var r = require("*/cartridge/scripts/util/Response");
  * @module controllers/Klaviyo
  */
 var Event = function () {
-
-    if (klaviyoUtils.klaviyoEnabled){
+    if (klaviyoUtils.klaviyoEnabled) {
         var kx = request.httpParameterMap.kx;
         var exchangeID = (!kx.empty) ? kx.stringValue : klaviyoUtils.getKlaviyoExchangeID();
         var isKlDebugOn = request.httpParameterMap.kldebug.booleanValue;
@@ -35,24 +33,24 @@ var Event = function () {
             action = request.httpParameterMap.action.stringValue;
             parms = request.httpParameterMap.parms.stringValue;
 
-            if(action != 'false') { // string test intentional, action passed as 'false' for pages that do not need to trigger events (Home, Page, Default)
-                switch(action) {
-                    case klaviyoUtils.EVENT_NAMES.viewedProduct :
-                        dataObj = viewedProductData.getData(parms); // parms: product ID
-                        break;
-                    case klaviyoUtils.EVENT_NAMES.viewedCategory :
-                        dataObj = viewedCategoryData.getData(parms); // parms: category ID
-                        break;
-                    case klaviyoUtils.EVENT_NAMES.searchedSite :
-                        parms = parms.split('|');
-                        dataObj = searchedSiteData.getData(parms[0], parms[1]); // parms: search phrase, result count
-                        break;
+            if (action != 'false') { // string test intentional, action passed as 'false' for pages that do not need to trigger events (Home, Page, Default)
+                switch (action) {
+                case klaviyoUtils.EVENT_NAMES.viewedProduct :
+                    dataObj = viewedProductData.getData(parms); // parms: product ID
+                    break;
+                case klaviyoUtils.EVENT_NAMES.viewedCategory :
+                    dataObj = viewedCategoryData.getData(parms); // parms: category ID
+                    break;
+                case klaviyoUtils.EVENT_NAMES.searchedSite :
+                    parms = parms.split('|');
+                    dataObj = searchedSiteData.getData(parms[0], parms[1]); // parms: search phrase, result count
+                    break;
                 }
                 serviceCallResult = klaviyoUtils.trackEvent(exchangeID, dataObj, action, false);
                 if (isKlDebugOn) {
                     app.getView({
-                        klDebugData: klaviyoUtils.prepareDebugData(dataObj),
-                        serviceCallData: klaviyoUtils.prepareDebugData(serviceCallResult)
+                        klDebugData     : klaviyoUtils.prepareDebugData(dataObj),
+                        serviceCallData : klaviyoUtils.prepareDebugData(serviceCallResult)
                     }).render('klaviyo/klaviyoDebug');
                     return;
                 }
@@ -60,8 +58,8 @@ var Event = function () {
         } else {
             // no klaviyo ID, check for SFCC profile and ID off that if extent
             var klid = klaviyoUtils.getProfileInfo();
-            if(klid) {
-                app.getView({klid: klid}).render('klaviyo/klaviyoID');
+            if (klid) {
+                app.getView({ klid: klid }).render('klaviyo/klaviyoID');
             }
         }
     }
@@ -69,14 +67,12 @@ var Event = function () {
 
 
 /* receives AJAX call from email field indicated by custom Site Preference "klaviyo_checkout_email_selector" */
-var StartedCheckoutEvent = function() {
-
+var StartedCheckoutEvent = function () {
     var KLCheckoutHelpers = require('*/cartridge/scripts/klaviyo/checkoutHelpers');
     var email = StringUtils.decodeBase64(request.httpParameterMap.a);
-    var KLTplVars = KLCheckoutHelpers.startedCheckoutHelper(true, email);
+    KLCheckoutHelpers.startedCheckoutHelper(true, email);
 
     res.json({ success: true });
-
 };
 
 exports.Event = guard.ensure(['get'], Event);

--- a/cartridges/int_klaviyo/cartridge/controllers/KlaviyoRecreate.js
+++ b/cartridges/int_klaviyo/cartridge/controllers/KlaviyoRecreate.js
@@ -2,7 +2,7 @@
 
 /* API Includes */
 var Logger = require('dw/system/Logger');
-const Resource = require('dw/web/Resource');
+var Resource = require('dw/web/Resource');
 var StringUtils = require('dw/util/StringUtils');
 var URLUtils = require('dw/web/URLUtils');
 

--- a/cartridges/int_klaviyo/cartridge/scripts/klaviyo/klaviyoATC.js
+++ b/cartridges/int_klaviyo/cartridge/scripts/klaviyo/klaviyoATC.js
@@ -25,7 +25,7 @@ function addProductToCart(decodedItems, cartObj) {
         var productToAdd;
         var template = 'checkout/cart/minicart';
 
-        for (let i = 0; i < productList.length; i++) {
+        for (var i = 0; i < productList.length; i++) {
             productToAdd = Product.get(productList[i].productID);
             productOptionModel = productToAdd ? recreateHelpers.updateOptions(productList[i], productToAdd.object) : null;
             cart.addProductItem(productToAdd.object, productList[i].quantity, productOptionModel);

--- a/cartridges/int_klaviyo/cartridge/scripts/klaviyo/klaviyoATC.js
+++ b/cartridges/int_klaviyo/cartridge/scripts/klaviyo/klaviyoATC.js
@@ -32,18 +32,18 @@ function addProductToCart(decodedItems, cartObj) {
         }
 
         return {
-            format: format,
-            template: template,
-            BonusDiscountLineItem: newBonusDiscountLineItem
+            format                : format,
+            template              : template,
+            BonusDiscountLineItem : newBonusDiscountLineItem
         };
     } catch (error) {
         var logger = Logger.getLogger('Klaviyo', 'Klaviyo.SiteGen recreateCartHelpers.js');
         logger.error('addProductToCart() failed. ERROR at: {0} {1}', error.message, error.stack)
 
         return {
-            success: false,
-            error: true,
-            errorMessage: `ERROR - Please check the encoded obj for any unexpected chars or syntax issues. ${error.message}`,
+            success      : false,
+            error        : true,
+            errorMessage : `ERROR - Please check the encoded obj for any unexpected chars or syntax issues. ${error.message}`,
         };
     }
 };
@@ -52,5 +52,5 @@ function addProductToCart(decodedItems, cartObj) {
  * Module exports
  */
 module.exports = {
-    addProductToCart : addProductToCart,
+    addProductToCart: addProductToCart,
 }

--- a/cartridges/int_klaviyo/cartridge/scripts/klaviyo/viewedProductHelpers.js
+++ b/cartridges/int_klaviyo/cartridge/scripts/klaviyo/viewedProductHelpers.js
@@ -7,7 +7,6 @@ var StringUtils = require('dw/util/StringUtils');
 var Logger = require('dw/system/Logger');
 
 /* Script Modules */
-var app = require('*/cartridge/scripts/app');
 var klaviyoUtils = require('*/cartridge/scripts/klaviyo/utils');
 
 
@@ -15,12 +14,14 @@ var klaviyoUtils = require('*/cartridge/scripts/klaviyo/utils');
 // This leverages SiteGen logic and expected properties to locate the original price book & promos to capture promotional prices that may be set on a given item.
 // It accepts a full product as a parameter and returns a simple object with four properties. Ex: { "price": INT, "priceString": STRING, "originalPrice": INT, "originalPriceString": STRING }
 function getProductPrices(product) {
-    var price, originalPrice, promoPrice;
+    var price;
+    var originalPrice;
+    var promoPrice;
     var orgProduct = product;
 
     product = (product.variationGroup) ? product.masterProduct : product;
 
-    if(product.master && !product.priceModel.isPriceRange() && product.variationModel.variants.size() > 0) {
+    if (product.master && !product.priceModel.isPriceRange() && product.variationModel.variants.size() > 0) {
         product = orgProduct.variationModel.variants[0];
     }
 
@@ -47,27 +48,26 @@ function getProductPrices(product) {
         }
 
         return {
-            price : price,
-            priceString : StringUtils.formatMoney(dw.value.Money( price, session.getCurrency().getCurrencyCode() )),
-            originalPrice : originalPrice,
-            originalPriceString : originalPrice ? StringUtils.formatMoney(dw.value.Money( originalPrice, session.getCurrency().getCurrencyCode() )) : null
-        }
-
-    } catch(e) {
+            price               : price,
+            priceString         : StringUtils.formatMoney(dw.value.Money(price, session.getCurrency().getCurrencyCode())),
+            originalPrice       : originalPrice,
+            originalPriceString : originalPrice ? StringUtils.formatMoney(dw.value.Money(originalPrice, session.getCurrency().getCurrencyCode())) : null
+        };
+    } catch (e) {
         var logger = Logger.getLogger('Klaviyo', 'Klaviyo.siteGen viewedProductHelper.js');
         logger.error('getProductPrices() failed to generate price data for product ' + product.ID + ': ' + e.message + ' ' + e.stack);
     }
 
     // fallback for failure to generate price data
     return {
-        price : 0,
-        priceString : 0,
-        originalPrice : 0,
+        price               : 0,
+        priceString         : 0,
+        originalPrice       : 0,
         originalPriceString : 0
-    }
+    };
 }
 
 
 module.exports = {
-    getProductPrices : getProductPrices
+    getProductPrices: getProductPrices
 };

--- a/cartridges/int_klaviyo/cartridge/scripts/klaviyo/viewedProductHelpers.js
+++ b/cartridges/int_klaviyo/cartridge/scripts/klaviyo/viewedProductHelpers.js
@@ -11,6 +11,9 @@ var app = require('*/cartridge/scripts/app');
 var klaviyoUtils = require('*/cartridge/scripts/klaviyo/utils');
 
 
+// The getProductPrices helper func is necessary to locate the correct 'purchase price' that's visible on the PDP.
+// This leverages SiteGen logic and expected properties to locate the original price book & promos to capture promotional prices that may be set on a given item.
+// It accepts a full product as a parameter and returns a simple object with four properties. Ex: { "price": INT, "priceString": STRING, "originalPrice": INT, "originalPriceString": STRING }
 function getProductPrices(product) {
     var price, originalPrice, promoPrice;
     var orgProduct = product;

--- a/cartridges/int_klaviyo/cartridge/templates/default/klaviyo/klaviyoFooter.isml
+++ b/cartridges/int_klaviyo/cartridge/templates/default/klaviyo/klaviyoFooter.isml
@@ -1,7 +1,7 @@
 <isscript>
     var klaviyoUtils = require('*/cartridge/scripts/klaviyo/utils');
 </isscript>
-<!--- TEMPLATENAME: klaviyoTag.isml --->
+<!--- TEMPLATENAME: klaviyoFooter.isml --->
 <isif condition="${klaviyoUtils.klaviyoEnabled}">
     <script async src="//static.klaviyo.com/onsite/js/klaviyo.js?company_id=${dw.system.Site.getCurrent().preferences.custom.klaviyo_account}"></script>
     <script>

--- a/cartridges/int_klaviyo/cartridge/templates/default/klaviyo/klaviyoFooter.isml
+++ b/cartridges/int_klaviyo/cartridge/templates/default/klaviyo/klaviyoFooter.isml
@@ -8,7 +8,7 @@
         // klaviyo object loader - provided by klaviyo
         !function(){if(!window.klaviyo){window._klOnsite=window._klOnsite||[];try{window.klaviyo=new Proxy({},{get:function(n,i){return"push"===i?function(){var n;(n=window._klOnsite).push.apply(n,arguments)}:function(){for(var n=arguments.length,o=new Array(n),w=0;w<n;w++)o[w]=arguments[w];var t="function"==typeof o[o.length-1]?o.pop():void 0,e=new Promise((function(n){window._klOnsite.push([i].concat(o,[function(i){t&&t(i),n(i)}]))}));return e}}})}catch(n){window.klaviyo=window.klaviyo||[],window.klaviyo.push=function(){var n;(n=window._klOnsite).push.apply(n,arguments)}}}}();
     </script>
-    <isif condition="${pageContext.type == 'product' || 
+    <isif condition="${pageContext.type == 'product' ||
         pageContext.type == 'search' ||
         pageContext.type == 'storefront'
         }">

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/checkoutHelpers.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/checkoutHelpers.js
@@ -12,29 +12,26 @@ var startedCheckoutData = require('*/cartridge/scripts/klaviyo/eventData/started
 // otherwise assume this is a continuation of checkout
 // customerEmail only passed if this is called from Klaviyo-StartedCheckoutEvent
 function startedCheckoutHelper(beginCheckout, customerEmail) {
-
     var returnObj = {
-        klid: false,
-        klDebugData: false,
-        serviceCallData: false
-    }
+        klid            : false,
+        klDebugData     : false,
+        serviceCallData : false
+    };
 
-    if(klaviyoUtils.klaviyoEnabled){
-
-        if(beginCheckout) {
+    if (klaviyoUtils.klaviyoEnabled) {
+        if (beginCheckout) {
             session.privacy.klaviyoCheckoutTracked = false;
         }
 
-        var klaviyoCheckoutTracked = session.privacy.klaviyoCheckoutTracked;
-
-        if(session.privacy.klaviyoCheckoutTracked == false) {
-
+        if (session.privacy.klaviyoCheckoutTracked == false) {
             var exchangeID = klaviyoUtils.getKlaviyoExchangeID();
-            var dataObj, serviceCallResult, currentBasket;
+            var dataObj;
+            var serviceCallResult;
+            var currentBasket;
             var isKlDebugOn = request.httpParameterMap.kldebug.booleanValue;
             currentBasket = BasketMgr.getCurrentBasket();
 
-            if ( customerEmail ) {
+            if (customerEmail) {
                 if (currentBasket && currentBasket.getProductLineItems().toArray().length) {
                     dataObj = startedCheckoutData.getData(currentBasket);
                     serviceCallResult = klaviyoUtils.trackEvent(exchangeID, dataObj, klaviyoUtils.EVENT_NAMES.startedCheckout, customerEmail);
@@ -45,22 +42,19 @@ function startedCheckoutHelper(beginCheckout, customerEmail) {
                 }
 
                 session.privacy.klaviyoCheckoutTracked = true;
-
             } else {
                 returnObj.klid = klaviyoUtils.getProfileInfo();
             }
-
         }
-
     }
 
     return returnObj;
-};
+}
 
 
 function getEmailFromBasket() {
     var currentBasket = BasketMgr.getCurrentBasket();
-    if(currentBasket && currentBasket.customerEmail) {
+    if (currentBasket && currentBasket.customerEmail) {
         return currentBasket.customerEmail;
     }
 
@@ -69,6 +63,6 @@ function getEmailFromBasket() {
 
 
 module.exports = {
-    startedCheckoutHelper: startedCheckoutHelper,
-    getEmailFromBasket: getEmailFromBasket
+    startedCheckoutHelper : startedCheckoutHelper,
+    getEmailFromBasket    : getEmailFromBasket
 };

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
@@ -36,7 +36,8 @@ function getData(basket) {
             }
 
             if (currentProductID != null && !empty(basketProduct) && basketProduct.getPriceModel().getPrice().value > 0) {
-                var primaryCategory, selectedOptions;
+                var primaryCategory;
+                var selectedOptions;
                 if (basketProduct.variant) {
                     primaryCategory = (basketProduct.masterProduct.primaryCategory) ? basketProduct.masterProduct.primaryCategory.displayName : '';
                 } else {
@@ -49,22 +50,22 @@ function getData(basket) {
 
                 var categories = [];
                 var catProduct = (basketProduct.variant) ? basketProduct.masterProduct : basketProduct; // from orig klav code, always use master for finding cats
-                for(var i = 0, len = catProduct.categoryAssignments.length; i < len; i++) {
+                for (var i = 0, len = catProduct.categoryAssignments.length; i < len; i++) {
                     categories.push(catProduct.categoryAssignments[i].category.displayName);
                 }
 
                 var currentLineItem = {
-                    productID       : currentProductID,
-                    productName     : basketProduct.name,
-                    productImageURL : imageSizeOfProduct,
-                    productPageURL  : URLUtils.https('Product-Show', 'pid', currentProductID).toString(),
+                    productID                 : currentProductID,
+                    productName               : basketProduct.name,
+                    productImageURL           : imageSizeOfProduct,
+                    productPageURL            : URLUtils.https('Product-Show', 'pid', currentProductID).toString(),
                     productUPC                : basketProduct.UPC,
                     viewedProductAvailability : basketProduct.availabilityModel.availability,
                     categories                : categories,
                     primaryCategory           : primaryCategory
                 };
 
-                if(!basketProduct.master && 'masterProduct' in basketProduct) {
+                if (!basketProduct.master && 'masterProduct' in basketProduct) {
                     currentLineItem.masterProductID = basketProduct.masterProduct.ID;
                 }
 
@@ -105,14 +106,13 @@ function getData(basket) {
 
         // Item added to the cart in this event
         // Bonus products can occasionally appear as final item in the cart. We exclude these from the line items to accurately track the item added to cart in this event.
-        for (let i = data.lineItems.length - 1; i >= 0; i--) {
-            if (!data.lineItems[i]['Is Bonus Product']) {
-                data.productAddedToCart = data.lineItems[i];
+        for (var idx = data.lineItems.length - 1; idx >= 0; idx--) {
+            if (!data.lineItems[idx]['Is Bonus Product']) {
+                data.productAddedToCart = data.lineItems[idx];
                 break;
             }
         }
-
-    } catch(e) {
+    } catch (e) {
         var logger = Logger.getLogger('Klaviyo', 'Klaviyo.core addedToCart.js');
         logger.error('addedToCart.getData() failed to create data object: ' + e.message + ' ' + e.stack);
     }
@@ -122,5 +122,5 @@ function getData(basket) {
 
 
 module.exports = {
-    getData : getData
+    getData: getData
 };

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/addedToCart.js
@@ -60,7 +60,7 @@ function getData(basket) {
                     productPageURL  : URLUtils.https('Product-Show', 'pid', currentProductID).toString(),
                     productUPC                : basketProduct.UPC,
                     viewedProductAvailability : basketProduct.availabilityModel.availability,
-                    categories                : categories, // was createCategories(basketProduct) in orig, check that my output from categories above matches expected output
+                    categories                : categories,
                     primaryCategory           : primaryCategory
                 };
 
@@ -113,7 +113,6 @@ function getData(basket) {
         }
 
     } catch(e) {
-        var errorTest = e;
         var logger = Logger.getLogger('Klaviyo', 'Klaviyo.core addedToCart.js');
         logger.error('addedToCart.getData() failed to create data object: ' + e.message + ' ' + e.stack);
     }

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
@@ -1,7 +1,6 @@
 'use strict';
 
 /* API Includes */
-var Site = require('dw/system/Site');
 var Logger = require('dw/system/Logger');
 var URLUtils = require('dw/web/URLUtils');
 var ProductMgr = require('dw/catalog/ProductMgr');
@@ -17,10 +16,8 @@ var KLImageSize = klaviyoUtils.KLImageSize;
  * @returns
  */
 function getData(order) {
-
     var data;
     try {
-
         data = {};
 
         // Billing Address
@@ -70,7 +67,7 @@ function getData(order) {
             for (var j in productLineItems) {
                 productLineItem = productLineItems[j];
                 var prdUrl = '';
-                prdUrl = URLUtils.https( 'Product-Show', 'pid', productLineItem.productID ).toString();
+                prdUrl = URLUtils.https('Product-Show', 'pid', productLineItem.productID).toString();
                 var secondaryName = '';
 
                 // Get the product secondary name
@@ -127,14 +124,14 @@ function getData(order) {
                     'Product ID'             : productLineItem.productID,
                     'Product Name'           : productLineItem.productName,
                     'Product Secondary Name' : secondaryName,
-                    'Quantity'                 : productLineItem.quantity.value,
-                    'Discount'                 : productLineItem.adjustedPrice.value,
+                    'Quantity'               : productLineItem.quantity.value,
+                    'Discount'               : productLineItem.adjustedPrice.value,
                     'Product Page URL'       : prdUrl,
                     'Product Variant'        : variationValues,
                     'Product Image URL'      : KLImageSize ? productDetail.getImage(KLImageSize).getAbsURL().toString() : null
                 };
 
-                if(!productDetail.master && 'masterProduct' in productDetail) {
+                if (!productDetail.master && 'masterProduct' in productDetail) {
                     currentLineItem['Master Product ID'] = productDetail.masterProduct.ID;
                 }
 
@@ -209,19 +206,19 @@ function getData(order) {
             var merchTotalInclOrderDiscounts = order.getAdjustedMerchandizeTotalPrice(true);
 
             // discounts
-            var orderDiscount = merchTotalExclOrderDiscounts.subtract( merchTotalInclOrderDiscounts );
-            var orderDiscountString = dw.util.StringUtils.formatMoney( dw.value.Money( orderDiscount.value, session.getCurrency().getCurrencyCode()) );
+            var orderDiscount = merchTotalExclOrderDiscounts.subtract(merchTotalInclOrderDiscounts);
+            var orderDiscountString = dw.util.StringUtils.formatMoney(dw.value.Money(orderDiscount.value, session.getCurrency().getCurrencyCode()));
 
             // Sub Total
             var subTotal = merchTotalInclOrderDiscounts;
-            var subTotalString = dw.util.StringUtils.formatMoney( dw.value.Money(subTotal.value, session.getCurrency().getCurrencyCode()) );
+            var subTotalString = dw.util.StringUtils.formatMoney(dw.value.Money(subTotal.value, session.getCurrency().getCurrencyCode()));
 
             // Shipping
             var shippingExclDiscounts = order.shippingTotalPrice;
             var shippingInclDiscounts = order.getAdjustedShippingTotalPrice();
             var shippingDiscount = shippingExclDiscounts.subtract(shippingInclDiscounts);
             var shippingTotalCost = shippingExclDiscounts.subtract(shippingDiscount);
-            var shippingTotalCostString = dw.util.StringUtils.formatMoney( dw.value.Money( shippingTotalCost.value, session.getCurrency().getCurrencyCode() ) );
+            var shippingTotalCostString = dw.util.StringUtils.formatMoney(dw.value.Money(shippingTotalCost.value, session.getCurrency().getCurrencyCode()));
 
             // Tax
             var totalTax = 0.0;
@@ -253,7 +250,7 @@ function getData(order) {
         }
 
         // Order Details
-        var orderCreationDate = dw.util.StringUtils.formatCalendar( new dw.util.Calendar(new Date(order.creationDate)), 'yyyy-MM-dd' );
+        var orderCreationDate = dw.util.StringUtils.formatCalendar(new dw.util.Calendar(new Date(order.creationDate)), 'yyyy-MM-dd');
         data['Order Number'] = order.orderNo;
         data['Order Date'] = orderCreationDate;
         data['Customer Number'] = order.customerNo ? order.customerNo : '';
@@ -269,13 +266,13 @@ function getData(order) {
         billingaddress.push({
             'First Name'   : orderBillingAddressFirstName,
             'Last Name'    : orderBillingAddressLastName,
-            'Address1'       : orderBillingAddressAddress1,
-            'Address2'       : orderBillingAddressAddress2,
-            'City'           : orderBillingAddressCity,
+            'Address1'     : orderBillingAddressAddress1,
+            'Address2'     : orderBillingAddressAddress2,
+            'City'         : orderBillingAddressCity,
             'Postal Code'  : orderShippingAddressPostalCode,
             'State Code'   : orderBillingAddressStateCode,
             'Country Code' : orderBillingAddressCountryCode,
-            'Phone'          : orderBillingAddressPhone
+            'Phone'        : orderBillingAddressPhone
         });
 
         // Shipping Address
@@ -283,13 +280,13 @@ function getData(order) {
         shippingaddress.push({
             'First Name'   : orderShippingAddressFirstName,
             'Last Name'    : orderShippingAddressLastName,
-            'Address1'       : orderShippingAddressAddress1,
-            'Address2'       : orderShippingAddressAddress2,
-            'City'           : orderShippingAddressCity,
+            'Address1'     : orderShippingAddressAddress1,
+            'Address2'     : orderShippingAddressAddress2,
+            'City'         : orderShippingAddressCity,
             'Postal Code'  : orderShippingAddressPostalCode,
             'State Code'   : orderShippingAddressStateCode,
             'Country Code' : orderShippingAddressCountryCode,
-            'Phone'          : orderShippingAddressPhone
+            'Phone'        : orderShippingAddressPhone
         });
 
         // Add product / billing / shipping
@@ -304,12 +301,10 @@ function getData(order) {
         data['$value'] = orderTotal;
         data['$event_id'] = 'orderConfirmation' + '-' + order.orderNo;
         data['Tracking Number'] = order.shipments[0].trackingNumber ? order.shipments[0].trackingNumber : '';
-
-    } catch(e) {
+    } catch (e) {
         var logger = Logger.getLogger('Klaviyo', 'Klaviyo.core orderConfirmation.js');
-        logger.error('orderConfirmation.getData() failed to create data object: '+e.message+' '+ e.stack );
+        logger.error('orderConfirmation.getData() failed to create data object: ' + e.message + ' ' + e.stack);
     }
-
     return data;
 }
 

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/searchedSite.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/searchedSite.js
@@ -3,12 +3,12 @@
 // prepares data for "Searched Site" event
 function getData(term, count) {
     return {
-        "Search Term": term,
-        "Search Results Count": count
-    }
+        'Search Term'          : term,
+        'Search Results Count' : count
+    };
 }
 
 
 module.exports = {
-    getData : getData
+    getData: getData
 };

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/startedCheckout.js
@@ -13,7 +13,6 @@ var KLImageSize = klaviyoUtils.KLImageSize;
 
 // prepares data for "Started Checkout" event
 function getData(currentBasket) {
-
     var data;
     try {
         data = {};
@@ -28,7 +27,7 @@ function getData(currentBasket) {
         data.Categories = [];
         data.Items = [];
         data.$email = currentBasket.customerEmail;
-        data.cartRebuildingLink = URLUtils.abs('KlaviyoRecreate-Cart').toString() + `?items=`;
+        data.cartRebuildingLink = URLUtils.abs('KlaviyoRecreate-Cart').toString() + '?items=';
 
         for (var itemIndex = 0; itemIndex < basketItems.length; itemIndex++) {
             var lineItem = basketItems[itemIndex];
@@ -41,9 +40,9 @@ function getData(currentBasket) {
             var options = lineItem && lineItem.optionProductLineItems ? klaviyoUtils.captureProductOptions(lineItem.optionProductLineItems) : null;
 
             if (currentProductID != null && !empty(basketProduct) && basketProduct.getPriceModel().getPrice().value > 0) {
-                var productObj = prepareProductObj( lineItem, basketProduct, currentProductID );
+                var productObj = prepareProductObj(lineItem, basketProduct, currentProductID);
 
-                if(!basketProduct.master && 'masterProduct' in basketProduct) {
+                if (!basketProduct.master && 'masterProduct' in basketProduct) {
                     productObj['Master Product ID'] = basketProduct.masterProduct.ID;
                 }
 
@@ -71,9 +70,9 @@ function getData(currentBasket) {
         }
 
         data.cartRebuildingLink += StringUtils.encodeBase64(JSON.stringify(reconstructCartItems));
-    } catch(e) {
+    } catch (e) {
         var logger = Logger.getLogger('Klaviyo', 'Klaviyo.core startedCheckout.js');
-        logger.error('startedCheckout.getData() failed to create data object: '+e.message+' '+ e.stack );
+        logger.error('startedCheckout.getData() failed to create data object: ' + e.message + ' ' + e.stack);
     }
     return data;
 }
@@ -106,7 +105,7 @@ function prepareProductObj(lineItem, basketProduct, currentProductID) {
 
     var categories = [];
     var catProduct = (basketProduct.variant) ? basketProduct.masterProduct : basketProduct;
-    for(var i = 0, len = catProduct.categoryAssignments.length; i < len; i++) {
+    for (var i = 0, len = catProduct.categoryAssignments.length; i < len; i++) {
         categories.push(catProduct.categoryAssignments[i].category.displayName);
     }
 
@@ -116,5 +115,5 @@ function prepareProductObj(lineItem, basketProduct, currentProductID) {
 
 
 module.exports = {
-    getData : getData
+    getData: getData
 };

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/viewedCategory.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/viewedCategory.js
@@ -2,10 +2,10 @@
 
 // prepares data for "Viewed Category" event
 function getData(categoryID) {
-    return { "Viewed Category": categoryID }
+    return { 'Viewed Category': categoryID };
 }
 
 
 module.exports = {
-    getData : getData
+    getData: getData
 };

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/viewedProduct.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/viewedProduct.js
@@ -4,7 +4,6 @@
 var Logger = require('dw/system/Logger');
 var ProductMgr = require('dw/catalog/ProductMgr');
 var URLUtils = require('dw/web/URLUtils');
-var StringUtils = require('dw/util/StringUtils');
 
 /* Script Modules */
 var klaviyoUtils = require('*/cartridge/scripts/klaviyo/utils');
@@ -13,10 +12,8 @@ var KLImageSize = klaviyoUtils.KLImageSize;
 
 // prepares data for "Viewed Product" event
 function getData(productID) {
-
     var data;
     try {
-
         data = {};
 
         // product in viewData is flat and doesn't have all data required (to whit, categories)
@@ -37,23 +34,22 @@ function getData(productID) {
         data['Original Price String'] = prices.originalPriceString ? prices.originalPriceString : prices.priceString;
         data['Product UPC'] = product.UPC;
 
-        if(!product.master && 'masterProduct' in product) {
+        if (!product.master && 'masterProduct' in product) {
             data['Master Product ID'] = product.masterProduct.ID;
         }
 
         var categories = [];
         var catProduct = (product.variant) ? product.masterProduct : product;
-        for(var i = 0, len = catProduct.categoryAssignments.length; i < len; i++) {
+        for (var i = 0, len = catProduct.categoryAssignments.length; i < len; i++) {
             categories.push(catProduct.categoryAssignments[i].category.displayName);
         }
         categories = klaviyoUtils.dedupeArray(categories);
 
         data['Categories'] = categories;
         data['Primary Category'] = !empty(catProduct.getPrimaryCategory()) ? catProduct.getPrimaryCategory().displayName : '';
-
-    } catch(e) {
+    } catch (e) {
         var logger = Logger.getLogger('Klaviyo', 'Klaviyo.core viewedProduct.js');
-        logger.error('viewedProduct.getData() failed to create data object: ' + e.message + ' ' + e.stack );
+        logger.error('viewedProduct.getData() failed to create data object: ' + e.message + ' ' + e.stack);
     }
 
     return data;
@@ -61,5 +57,5 @@ function getData(productID) {
 
 
 module.exports = {
-    getData : getData
+    getData: getData
 };

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/recreateCartHelpers.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/recreateCartHelpers.js
@@ -7,7 +7,7 @@ var PromotionMgr = require('dw/campaign/PromotionMgr');
 // The clearCart function is necessary iterate through all items in the cart to clear it and ensure a clean slate
 // (Note: ensures consistency with price, product items and shipping when refreshing the page or loading the page for the first time)
 function clearCart(cartObj) {
-    for (let i = cartObj.allProductLineItems.length - 1; i >= 0; i--) {
+    for (var i = cartObj.allProductLineItems.length - 1; i >= 0; i--) {
         let currItem = cartObj.allProductLineItems[i];
         cartObj.removeProductLineItem(cartObj.allProductLineItems[i]);
     }

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/recreateCartHelpers.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/recreateCartHelpers.js
@@ -8,7 +8,6 @@ var PromotionMgr = require('dw/campaign/PromotionMgr');
 // (Note: ensures consistency with price, product items and shipping when refreshing the page or loading the page for the first time)
 function clearCart(cartObj) {
     for (var i = cartObj.allProductLineItems.length - 1; i >= 0; i--) {
-        let currItem = cartObj.allProductLineItems[i];
         cartObj.removeProductLineItem(cartObj.allProductLineItems[i]);
     }
 
@@ -23,7 +22,7 @@ function updateOptions(params, product) {
     var optionModel = product.getOptionModel();
 
     for (var i = 0; i < params.options.length; i++) {
-        var optionID      = params.options[i]['Option ID'];
+        var optionID = params.options[i]['Option ID'];
         var optionValueID = params.options[i]['Option Value ID'];
 
         if (optionValueID) {
@@ -43,6 +42,6 @@ function updateOptions(params, product) {
 
 
 module.exports = {
-    clearCart: clearCart,
-    updateOptions: updateOptions
+    clearCart     : clearCart,
+    updateOptions : updateOptions
 };

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/services.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/services.js
@@ -59,10 +59,10 @@ var KlaviyoEventService = ServiceRegistry.createService('KlaviyoEventService', {
     getResponseLogMessage: function (response) {
         try {
             var r = {
-                statusCode: response.statusCode,
-                statusMessage: response.statusMessage,
-                errorText: response.errorText,
-                text: response.text
+                statusCode    : response.statusCode,
+                statusMessage : response.statusMessage,
+                errorText     : response.errorText,
+                text          : response.text
             };
 
             return JSON.stringify(r);
@@ -79,5 +79,5 @@ var KlaviyoEventService = ServiceRegistry.createService('KlaviyoEventService', {
 
 
 module.exports = {
-    KlaviyoEventService : KlaviyoEventService
+    KlaviyoEventService: KlaviyoEventService
 };

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/services.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/services.js
@@ -11,13 +11,13 @@ var KlaviyoEventService = ServiceRegistry.createService('KlaviyoEventService', {
 
     /**
    * Create the service request
-   * - Set request method to be the HTTP GET method
+   * - Set request method to be the HTTP POST method
    * - Construct request URL
    * - Append the request HTTP query string as a URL parameter
    *
    * @param {dw.svc.HTTPService} svc - HTTP Service instance
-   * @param {Object} params - Additional paramaters
-   * @returns {void}
+   * @param {Object} args - Additional paramaters
+   * @returns {String} - A JSON string of the args
    */
     createRequest: function (svc, args) {
 

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -15,9 +15,7 @@ var EVENT_NAMES = {
     'searchedSite' : 'Searched Site',
     'addedToCart' : 'Added to Cart',
     'startedCheckout' : 'Started Checkout',
-    'orderConfirmation' : 'Order Confirmation',
-    'placedOrder' : 'Placed Order',
-    'orderedProduct' : 'Ordered Product'
+    'orderConfirmation' : 'Order Confirmation'
 };
 
 var klaviyoEnabled = Site.getCurrent().getCustomPreferenceValue('klaviyo_enabled') || false;

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -10,12 +10,12 @@ var klaviyoServices = require('*/cartridge/scripts/klaviyo/services.js');
 
 // event name constants
 var EVENT_NAMES = {
-    'viewedProduct'     : 'Viewed Product',
-    'viewedCategory'    : 'Viewed Category',
-    'searchedSite'      : 'Searched Site',
-    'addedToCart'       : 'Added to Cart',
-    'startedCheckout'   : 'Started Checkout',
-    'orderConfirmation' : 'Order Confirmation'
+    viewedProduct     : 'Viewed Product',
+    viewedCategory    : 'Viewed Category',
+    searchedSite      : 'Searched Site',
+    addedToCart       : 'Added to Cart',
+    startedCheckout   : 'Started Checkout',
+    orderConfirmation : 'Order Confirmation'
 };
 
 var klaviyoEnabled = Site.getCurrent().getCustomPreferenceValue('klaviyo_enabled') || false;
@@ -37,9 +37,9 @@ function getKlaviyoExchangeID() {
 function getProfileInfo() {
     if (customer.authenticated && customer.profile) {
         var profileInfo = {
-            '$email'      : customer.profile.email,
-            '$first_name' : customer.profile.firstName,
-            '$last_name'  : customer.profile.lastName
+            $email      : customer.profile.email,
+            $first_name : customer.profile.firstName,
+            $last_name  : customer.profile.lastName
         };
         profileInfo = JSON.stringify(profileInfo);
         profileInfo = StringUtils.encodeBase64(profileInfo);
@@ -177,9 +177,9 @@ function trackEvent(exchangeID, data, event, customerEmail) {
     */
     var metricObj = {};
     if (event != EVENT_NAMES.addedToCart || (event == EVENT_NAMES.addedToCart && !Site.getCurrent().getCustomPreferenceValue('klaviyo_atc_override'))) {
-        metricObj = { 'name': event };
+        metricObj = { name: event };
     } else {
-        metricObj = { 'name': 'Add To Cart' };
+        metricObj = { name: 'Add To Cart' };
     }
     /* IMPORTANT:
         If the klaviyo_sendEventsAsSFCC site preference has been set to Yes (true) events will show up in the Klaviyo Dashboard with SFCC as the event provider.
@@ -193,19 +193,19 @@ function trackEvent(exchangeID, data, event, customerEmail) {
 
     var profileObj = {};
     if (!customerEmail) {
-        profileObj = { '$exchange_id': exchangeID };
+        profileObj = { $exchange_id: exchangeID };
     } else {
-        profileObj = { '$email': customerEmail };
+        profileObj = { $email: customerEmail };
     }
 
     var eventData = {
-        'data': {
-            'type'       : 'event',
-            'attributes' : {
-                'profile'    : profileObj,
-                'metric'     : metricObj,
-                'properties' : data,
-                'time'       : (new Date()).toISOString()
+        data: {
+            type       : 'event',
+            attributes : {
+                profile    : profileObj,
+                metric     : metricObj,
+                properties : data,
+                time       : (new Date()).toISOString()
             }
         }
     };

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -10,11 +10,11 @@ var klaviyoServices = require('*/cartridge/scripts/klaviyo/services.js');
 
 // event name constants
 var EVENT_NAMES = {
-    'viewedProduct' : 'Viewed Product',
-    'viewedCategory' : 'Viewed Category',
-    'searchedSite' : 'Searched Site',
-    'addedToCart' : 'Added to Cart',
-    'startedCheckout' : 'Started Checkout',
+    'viewedProduct'     : 'Viewed Product',
+    'viewedCategory'    : 'Viewed Category',
+    'searchedSite'      : 'Searched Site',
+    'addedToCart'       : 'Added to Cart',
+    'startedCheckout'   : 'Started Checkout',
     'orderConfirmation' : 'Order Confirmation'
 };
 
@@ -25,7 +25,7 @@ var KLImageSize = Site.getCurrent().getCustomPreferenceValue('klaviyo_image_size
 // looks for klaviyo's cookie and if found extracts the exchangeID from it, returning that value
 // if the cookie is not found or exchangeID extraction fails, returns false
 function getKlaviyoExchangeID() {
-    if('__kla_id' in request.httpCookies && !empty(request.httpCookies['__kla_id'])) {
+    if ('__kla_id' in request.httpCookies && !empty(request.httpCookies['__kla_id'])) {
         var kx = JSON.parse(StringUtils.decodeBase64(request.httpCookies['__kla_id'].value)).$exchange_id;
         return (kx && kx != '') ? kx : false;
     }
@@ -35,11 +35,11 @@ function getKlaviyoExchangeID() {
 
 // gets SFCC profile info (if available) to use for IDing user to klaviyo
 function getProfileInfo() {
-    if(customer.authenticated && customer.profile) {
+    if (customer.authenticated && customer.profile) {
         var profileInfo = {
-            "$email" : customer.profile.email,
-            "$first_name" : customer.profile.firstName,
-            "$last_name" : customer.profile.lastName
+            '$email'      : customer.profile.email,
+            '$first_name' : customer.profile.firstName,
+            '$last_name'  : customer.profile.lastName
         };
         profileInfo = JSON.stringify(profileInfo);
         profileInfo = StringUtils.encodeBase64(profileInfo);
@@ -77,16 +77,16 @@ function captureProductOptions(prodOptions) {
     var options = Array.isArray(prodOptions) ? prodOptions : Array.from(prodOptions);
     var selectedOptions = [];
 
-    options.forEach(optionObj => {
-        var formattedOptionPrice = optionObj ? StringUtils.formatMoney(dw.value.Money( optionObj.basePrice.value, session.getCurrency().getCurrencyCode() )) : null;
+    options.forEach(function (optionObj) {
+        var formattedOptionPrice = optionObj ? StringUtils.formatMoney(dw.value.Money(optionObj.basePrice.value, session.getCurrency().getCurrencyCode())) : null;
         selectedOptions.push({
-            'Line Item Text': optionObj.lineItemText,
-            'Option ID': optionObj.optionID,
-            'Option Value ID': optionObj.optionValueID,
-            'Option Price': formattedOptionPrice,
-            'Option Price Value': optionObj.basePrice.value
+            'Line Item Text'     : optionObj.lineItemText,
+            'Option ID'          : optionObj.optionID,
+            'Option Value ID'    : optionObj.optionValueID,
+            'Option Price'       : formattedOptionPrice,
+            'Option Price Value' : optionObj.basePrice.value
         });
-    })
+    });
 
     return selectedOptions;
 }
@@ -98,7 +98,7 @@ function captureProductBundles(bundledProducts) {
     var prodBundleData = {};
     prodBundleData.prodBundleIDs = [];
     prodBundleData.isProdBundle = true;
-    for (let i = 0; i < bundledProducts.length; i++) {
+    for (var i = 0; i < bundledProducts.length; i++) {
         var childObj = bundledProducts[i];
         prodBundleData.prodBundleIDs.push(childObj.productID);
     }
@@ -109,12 +109,12 @@ function captureProductBundles(bundledProducts) {
 
 // helper function to handle bonus products & set appropriate properties on a returned object.
 // Used in two key tracked events: 'Started Checkout' and 'Order Confirmation'.
-function captureBonusProduct (lineItemObj, prodObj) {
+function captureBonusProduct(lineItemObj, prodObj) {
     var bonusProductData = {};
     bonusProductData.isbonusProduct = true;
-    bonusProductData.originalPrice = StringUtils.formatMoney(dw.value.Money( prodObj.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode() ));
+    bonusProductData.originalPrice = StringUtils.formatMoney(dw.value.Money(prodObj.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode()));
     bonusProductData.originalPriceValue = prodObj.getPriceModel().getPrice().value;
-    bonusProductData.price = StringUtils.formatMoney(dw.value.Money( lineItemObj.adjustedPrice.value, session.getCurrency().getCurrencyCode() ));
+    bonusProductData.price = StringUtils.formatMoney(dw.value.Money(lineItemObj.adjustedPrice.value, session.getCurrency().getCurrencyCode()));
     bonusProductData.priceValue = lineItemObj.adjustedPrice.value;
 
     return bonusProductData;
@@ -123,26 +123,26 @@ function captureBonusProduct (lineItemObj, prodObj) {
 
 // helper function to consider promos & set Price and Original Pride properties on a returned object.
 // Used in order level events: 'Started Checkout' and 'Order Confirmation'.
-function priceCheck (lineItemObj, basketProdObj) {
+function priceCheck(lineItemObj, basketProdObj) {
     var priceModel = basketProdObj ? basketProdObj.getPriceModel() : null;
     var priceBook = priceModel ? getRootPriceBook(priceModel.priceInfo.priceBook) : null;
     var priceBookPrice = priceBook && priceModel ? priceModel.getPriceBookPrice(priceBook.ID) : null;
     var priceData = {};
 
-    var adjustedPromoPrice = lineItemObj && lineItemObj.adjustedPrice < priceBookPrice ? StringUtils.formatMoney(dw.value.Money( lineItemObj.adjustedPrice.value, session.getCurrency().getCurrencyCode() )) : null;
+    var adjustedPromoPrice = lineItemObj && lineItemObj.adjustedPrice < priceBookPrice ? StringUtils.formatMoney(dw.value.Money(lineItemObj.adjustedPrice.value, session.getCurrency().getCurrencyCode())) : null;
     if (adjustedPromoPrice) {
-        priceData.purchasePrice = StringUtils.formatMoney(dw.value.Money( lineItemObj.adjustedPrice.value, session.getCurrency().getCurrencyCode() ));
+        priceData.purchasePrice = StringUtils.formatMoney(dw.value.Money(lineItemObj.adjustedPrice.value, session.getCurrency().getCurrencyCode()));
         priceData.purchasePriceValue = lineItemObj.adjustedPrice.value;
-        priceData.originalPrice = priceBookPrice ? StringUtils.formatMoney(dw.value.Money( priceBookPrice.value, session.getCurrency().getCurrencyCode() )) : StringUtils.formatMoney(dw.value.Money( basketProdObj.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode() ));
+        priceData.originalPrice = priceBookPrice ? StringUtils.formatMoney(dw.value.Money(priceBookPrice.value, session.getCurrency().getCurrencyCode())) : StringUtils.formatMoney(dw.value.Money(basketProdObj.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode()));
         priceData.originalPriceValue = priceBookPrice.value;
     } else {
-        priceData.purchasePrice = lineItemObj ? StringUtils.formatMoney(dw.value.Money( lineItemObj.price.value, session.getCurrency().getCurrencyCode() )) : null;
+        priceData.purchasePrice = lineItemObj ? StringUtils.formatMoney(dw.value.Money(lineItemObj.price.value, session.getCurrency().getCurrencyCode())) : null;
         priceData.purchasePriceValue = lineItemObj ? lineItemObj.price.value : null;
-        priceData.originalPrice = basketProdObj ? StringUtils.formatMoney(dw.value.Money( basketProdObj.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode() )) : null;
+        priceData.originalPrice = basketProdObj ? StringUtils.formatMoney(dw.value.Money(basketProdObj.getPriceModel().getPrice().value, session.getCurrency().getCurrencyCode())) : null;
         priceData.originalPriceValue = basketProdObj.getPriceModel().getPrice().value;
     }
 
-    return priceData
+    return priceData;
 }
 
 
@@ -161,9 +161,6 @@ function getRootPriceBook(priceBook) {
 
 
 function trackEvent(exchangeID, data, event, customerEmail) {
-
-    var requestBody = {};
-    var resultObj = {};
     var logger = Logger.getLogger('Klaviyo', 'Klaviyo.core utils.js - trackEvent()');
 
     if (klaviyoServices.KlaviyoEventService == null || empty(exchangeID)) {
@@ -178,11 +175,11 @@ function trackEvent(exchangeID, data, event, customerEmail) {
         this site that did not label ATC events as "Added To Cart" there will be a break in reporting and functionality between past events that were not
         labelled with "Add To Cart" and the new events that are labelled "Added To Cart".  If in doubt, leave the site preference set to No and contact Klaviyo technical support.
     */
-    var metricObj = {}
-    if(event != EVENT_NAMES.addedToCart || (event == EVENT_NAMES.addedToCart && !Site.getCurrent().getCustomPreferenceValue('klaviyo_atc_override'))) {
-        metricObj = { "name": event };
+    var metricObj = {};
+    if (event != EVENT_NAMES.addedToCart || (event == EVENT_NAMES.addedToCart && !Site.getCurrent().getCustomPreferenceValue('klaviyo_atc_override'))) {
+        metricObj = { 'name': event };
     } else {
-        metricObj = { "name": 'Add To Cart' }
+        metricObj = { 'name': 'Add To Cart' };
     }
     /* IMPORTANT:
         If the klaviyo_sendEventsAsSFCC site preference has been set to Yes (true) events will show up in the Klaviyo Dashboard with SFCC as the event provider.
@@ -190,25 +187,25 @@ function trackEvent(exchangeID, data, event, customerEmail) {
         this site that did not label events with SFCC as provider there will be a break in reporting and functionality between past events that were not
         labelled with SFCC as provider and the new events that are.  If in doubt, leave the site preference set to No and contact Klaviyo technical support.
     */
-    if(Site.getCurrent().getCustomPreferenceValue('klaviyo_sendEventsAsSFCC')) {
-        metricObj.service = "demandware"
+    if (Site.getCurrent().getCustomPreferenceValue('klaviyo_sendEventsAsSFCC')) {
+        metricObj.service = 'demandware';
     }
 
     var profileObj = {};
-    if(!customerEmail) {
-        profileObj = { "$exchange_id": exchangeID }
+    if (!customerEmail) {
+        profileObj = { '$exchange_id': exchangeID };
     } else {
-        profileObj = { "$email": customerEmail }
+        profileObj = { '$email': customerEmail };
     }
 
     var eventData = {
-        "data": {
-            "type": "event",
-            "attributes": {
-                "profile": profileObj,
-                "metric": metricObj,
-                "properties" : data,
-                "time": (new Date()).toISOString()
+        'data': {
+            'type'       : 'event',
+            'attributes' : {
+                'profile'    : profileObj,
+                'metric'     : metricObj,
+                'properties' : data,
+                'time'       : (new Date()).toISOString()
             }
         }
     };
@@ -229,17 +226,17 @@ function trackEvent(exchangeID, data, event, customerEmail) {
 
 
 module.exports = {
-    EVENT_NAMES : EVENT_NAMES,
-    klaviyoEnabled : klaviyoEnabled,
-    KLImageSize : KLImageSize,
-    getKlaviyoExchangeID : getKlaviyoExchangeID,
-    getProfileInfo : getProfileInfo,
-    prepareDebugData : prepareDebugData,
-    dedupeArray: dedupeArray,
+    EVENT_NAMES           : EVENT_NAMES,
+    klaviyoEnabled        : klaviyoEnabled,
+    KLImageSize           : KLImageSize,
+    getKlaviyoExchangeID  : getKlaviyoExchangeID,
+    getProfileInfo        : getProfileInfo,
+    prepareDebugData      : prepareDebugData,
+    dedupeArray           : dedupeArray,
     captureProductOptions : captureProductOptions,
     captureProductBundles : captureProductBundles,
-    captureBonusProduct : captureBonusProduct,
-    priceCheck : priceCheck,
-    getRootPriceBook : getRootPriceBook,
-    trackEvent : trackEvent
+    captureBonusProduct   : captureBonusProduct,
+    priceCheck            : priceCheck,
+    getRootPriceBook      : getRootPriceBook,
+    trackEvent            : trackEvent
 };

--- a/cartridges/int_klaviyo_sfra/cartridge/controllers/Account.js
+++ b/cartridges/int_klaviyo_sfra/cartridge/controllers/Account.js
@@ -8,7 +8,7 @@ var klaviyoUtils = require('*/cartridge/scripts/klaviyo/utils');
 
 
 server.append('Show', function (req, res, next) {
-    if(klaviyoUtils.klaviyoEnabled && !klaviyoUtils.getKlaviyoExchangeID()){
+    if (klaviyoUtils.klaviyoEnabled && !klaviyoUtils.getKlaviyoExchangeID()) {
         res.viewData.klid = klaviyoUtils.getProfileInfo();
     }
 

--- a/cartridges/int_klaviyo_sfra/cartridge/controllers/Cart.js
+++ b/cartridges/int_klaviyo_sfra/cartridge/controllers/Cart.js
@@ -12,7 +12,7 @@ var addedToCartData = require('*/cartridge/scripts/klaviyo/eventData/addedToCart
 
 
 server.append('Show', function (req, res, next) {
-    if(klaviyoUtils.klaviyoEnabled && !klaviyoUtils.getKlaviyoExchangeID()){
+    if (klaviyoUtils.klaviyoEnabled && !klaviyoUtils.getKlaviyoExchangeID()) {
         res.viewData.klid = klaviyoUtils.getProfileInfo();
     }
 
@@ -20,11 +20,11 @@ server.append('Show', function (req, res, next) {
 });
 
 server.append('AddProduct', function (req, res, next) {
-
-    if(klaviyoUtils.klaviyoEnabled){
-
+    if (klaviyoUtils.klaviyoEnabled) {
         var exchangeID = klaviyoUtils.getKlaviyoExchangeID();
-        var dataObj, serviceCallResult, currentBasket;
+        var dataObj;
+        var serviceCallResult;
+        var currentBasket;
         var isKlDebugOn = request.getHttpReferer().includes('kldebug=true') ? true : false;
 
         if (exchangeID) {
@@ -35,7 +35,7 @@ server.append('AddProduct', function (req, res, next) {
                 serviceCallResult = klaviyoUtils.trackEvent(exchangeID, dataObj, klaviyoUtils.EVENT_NAMES.addedToCart, false);
                 if (isKlDebugOn) {
                     res.json({
-                        klDebugData : klaviyoUtils.prepareDebugData(dataObj),
+                        klDebugData     : klaviyoUtils.prepareDebugData(dataObj),
                         serviceCallData : klaviyoUtils.prepareDebugData(serviceCallResult)
                     });
                 }

--- a/cartridges/int_klaviyo_sfra/cartridge/controllers/Klaviyo.js
+++ b/cartridges/int_klaviyo_sfra/cartridge/controllers/Klaviyo.js
@@ -16,7 +16,7 @@ var KLCheckoutHelpers = require('*/cartridge/scripts/klaviyo/checkoutHelpers');
 /***
  *
  * NOTE: The Klaviyo-Event route exists to support event tracking on pages whose OOTB SFCC controllers are cached by default.
- * To avoid caching event data, the Klaviyo-Event route is called via remote include in KlaviyoTag.isml.
+ * To avoid caching event data, the Klaviyo-Event route is called via remote include in klaviyoFooter.isml.
  * For event tracking on pages whose controllers are not cached OOTB, server.appends to those OOTB controllers should be utilized.
  * Reference Cart.js, Checkout.js, Order.js in the int_klaviyo_sfra cartridge
  *

--- a/cartridges/int_klaviyo_sfra/cartridge/controllers/Klaviyo.js
+++ b/cartridges/int_klaviyo_sfra/cartridge/controllers/Klaviyo.js
@@ -13,20 +13,21 @@ var searchedSiteData = require('*/cartridge/scripts/klaviyo/eventData/searchedSi
 var KLCheckoutHelpers = require('*/cartridge/scripts/klaviyo/checkoutHelpers');
 
 
-/***
- *
- * NOTE: The Klaviyo-Event route exists to support event tracking on pages whose OOTB SFCC controllers are cached by default.
- * To avoid caching event data, the Klaviyo-Event route is called via remote include in klaviyoFooter.isml.
- * For event tracking on pages whose controllers are not cached OOTB, server.appends to those OOTB controllers should be utilized.
- * Reference Cart.js, Checkout.js, Order.js in the int_klaviyo_sfra cartridge
- *
- * Also note that this route gets called via remote include for Home-Show, Page-Show and Default-Start only to check for identifying users to Klaviyo off the user's SFCC Profile.
-***/
+/**
+     *
+     * NOTE: The Klaviyo-Event route exists to support event tracking on pages whose OOTB SFCC controllers are cached by default.
+     * To avoid caching event data, the Klaviyo-Event route is called via remote include in klaviyoFooter.isml.
+     * For event tracking on pages whose controllers are not cached OOTB, server.appends to those OOTB controllers should be utilized.
+     * Reference Cart.js, Checkout.js, Order.js in the int_klaviyo_sfra cartridge
+     *
+     * Also note that this route gets called via remote include for Home-Show, Page-Show and Default-Start only to check for identifying users to Klaviyo off the user's SFCC Profile.
+**/
 server.get('Event', function (req, res, next) {
-
-    if(klaviyoUtils.klaviyoEnabled){
-
-        var dataObj, serviceCallResult, action, parms;
+    if (klaviyoUtils.klaviyoEnabled) {
+        var dataObj;
+        var serviceCallResult;
+        var action;
+        var parms;
         var kx = request.httpParameterMap.kx;
         var isKlDebugOn = request.httpParameterMap.kldebug.booleanValue;
         var exchangeID = (!kx.empty) ? kx.stringValue : klaviyoUtils.getKlaviyoExchangeID();
@@ -35,18 +36,18 @@ server.get('Event', function (req, res, next) {
             action = request.httpParameterMap.action.stringValue;
             parms = request.httpParameterMap.parms.stringValue;
 
-            if(action != 'false') { // string test intentional, action passed as 'false' for pages that do not need to trigger events (Home, Page, Default)
-                switch(action) {
-                    case klaviyoUtils.EVENT_NAMES.viewedProduct :
-                        dataObj = viewedProductData.getData(parms); // parms: product ID
-                        break;
-                    case klaviyoUtils.EVENT_NAMES.viewedCategory :
-                        dataObj = viewedCategoryData.getData(parms); // parms: category ID
-                        break;
-                    case klaviyoUtils.EVENT_NAMES.searchedSite :
-                        parms = parms.split('|');
-                        dataObj = searchedSiteData.getData(parms[0], parms[1]); // parms: search phrase, result count
-                        break;
+            if (action != 'false') { // string test intentional, action passed as 'false' for pages that do not need to trigger events (Home, Page, Default)
+                switch (action) {
+                case klaviyoUtils.EVENT_NAMES.viewedProduct :
+                    dataObj = viewedProductData.getData(parms); // parms: product ID
+                    break;
+                case klaviyoUtils.EVENT_NAMES.viewedCategory :
+                    dataObj = viewedCategoryData.getData(parms); // parms: category ID
+                    break;
+                case klaviyoUtils.EVENT_NAMES.searchedSite :
+                    parms = parms.split('|');
+                    dataObj = searchedSiteData.getData(parms[0], parms[1]); // parms: search phrase, result count
+                    break;
                 }
                 serviceCallResult = klaviyoUtils.trackEvent(exchangeID, dataObj, action, false);
                 if (isKlDebugOn) {
@@ -57,7 +58,6 @@ server.get('Event', function (req, res, next) {
                     return;
                 }
             }
-
         } else {
             // no klaviyo ID, check for SFCC profile and ID off that if extant
             res.viewData.klid = klaviyoUtils.getProfileInfo();
@@ -70,9 +70,9 @@ server.get('Event', function (req, res, next) {
 
 
 /* receives AJAX call from email field indicated by custom Site Preference "klaviyo_checkout_email_selector" */
-server.post('StartedCheckoutEvent', server.middleware.https, function(req, res, next) {
+server.post('StartedCheckoutEvent', server.middleware.https, function (req, res, next) {
     var email = StringUtils.decodeBase64(req.httpParameterMap.a);
-    var templateVars = KLCheckoutHelpers.startedCheckoutHelper(true, email);
+    KLCheckoutHelpers.startedCheckoutHelper(true, email);
 
     res.json({ success: true });
 

--- a/cartridges/int_klaviyo_sfra/cartridge/controllers/KlaviyoRecreate.js
+++ b/cartridges/int_klaviyo_sfra/cartridge/controllers/KlaviyoRecreate.js
@@ -62,7 +62,7 @@ server.get('Cart', function (req, res, next) {
     try {
         Transaction.wrap(function () {
             if (items && items.length) {
-                for (let i = 0; i < items.length; i++) {
+                for (var i = 0; i < items.length; i++) {
                     var productToAdd = ProductMgr.getProduct(items[i].productID);
                     if (!productToAdd) {
                         throw new Error('Product with ID [' + items[i].productID + '] not found');
@@ -91,8 +91,8 @@ server.get('Cart', function (req, res, next) {
         logger.error('Transaction failed in KlaviyoRecreate-Cart controller. ERROR: {0} {1}', error.message, error.stack)
 
         res.render('error', {
-            error: true,
-            message: Resource.msgf('rebuildcart.message.error.transaction', 'klaviyo_error', null, error.message)
+            error   : true,
+            message : Resource.msgf('rebuildcart.message.error.transaction', 'klaviyo_error', null, error.message)
         });
     }
     next();

--- a/cartridges/int_klaviyo_sfra/cartridge/controllers/Order.js
+++ b/cartridges/int_klaviyo_sfra/cartridge/controllers/Order.js
@@ -12,14 +12,14 @@ var orderConfirmationData = require('*/cartridge/scripts/klaviyo/eventData/order
 
 
 server.append('Confirm', function (req, res, next) {
-
-    if(klaviyoUtils.klaviyoEnabled){
-
+    if (klaviyoUtils.klaviyoEnabled) {
         // resetting to default state after successful checkout
         req.session.privacyCache.set('klaviyoCheckoutTracked', false);
 
         var exchangeID = klaviyoUtils.getKlaviyoExchangeID();
-        var dataObj, serviceCallResult, currentOrder;
+        var dataObj;
+        var serviceCallResult;
+        var currentOrder;
 
         if(req.form.orderID && req.form.orderToken) {
             currentOrder = OrderMgr.getOrder(req.form.orderID, req.form.orderToken);

--- a/cartridges/int_klaviyo_sfra/cartridge/scripts/klaviyo/viewedProductHelpers.js
+++ b/cartridges/int_klaviyo_sfra/cartridge/scripts/klaviyo/viewedProductHelpers.js
@@ -16,14 +16,14 @@ function getProductPrices(product) {
     var fullPriceFormatted = fullProduct.price.sales ? fullProduct.price.sales.formatted : fullProduct.price.min.sales.formatted;
 
     return {
-        price : fullPriceValue,
-        priceString : fullPriceFormatted,
-        originalPrice : fullProduct.price.list ? fullProduct.price.list.value : fullPriceValue,
+        price               : fullPriceValue,
+        priceString         : fullPriceFormatted,
+        originalPrice       : fullProduct.price.list ? fullProduct.price.list.value : fullPriceValue,
         originalPriceString : fullProduct.price.list ? fullProduct.price.list.formatted : fullPriceFormatted
-    }
+    };
 }
 
 
 module.exports = {
-    getProductPrices : getProductPrices
+    getProductPrices: getProductPrices
 };

--- a/cartridges/int_klaviyo_sfra/cartridge/scripts/klaviyo/viewedProductHelpers.js
+++ b/cartridges/int_klaviyo_sfra/cartridge/scripts/klaviyo/viewedProductHelpers.js
@@ -5,6 +5,9 @@ var fullProductModel = require('*/cartridge/models/product/fullProduct');
 var productHelper = require('*/cartridge/scripts/helpers/productHelpers');
 
 
+// The getProductPrices helper func is necessary to locate the correct 'purchase price' that's visible on the PDP.
+// This leverages SFRA logic and expected properties to locate the original price book & promos to capture promotional prices that may be set on a given item. Core SFRA logic is used to locate the correct price.
+// It accepts a full product as a parameter and returns a simple object with four properties. Ex: { "price": INT, "priceString": STRING, "originalPrice": INT, "originalPriceString": STRING }
 function getProductPrices(product) {
     var options = productHelper.getConfig(product, { pid: product.ID });
     var newProdObj = Object.create(Object.prototype);

--- a/test/README.md
+++ b/test/README.md
@@ -56,7 +56,7 @@ Unit Tests verify the following
 
 - Track Event
 - Viewed Product
-- Oder Confirmation
+- Order Confirmation
 - Added to Cart
 - Started Checkout
 


### PR DESCRIPTION
## Description

This PR resolves the majority of the linter errors flagged in the Initial Check-in of new Klaviyo Cartridge PR ([linked here](https://github.com/klaviyo/SFCC_Klaviyo/pull/25)). It also includes some adjustments to address reviewer feedback.


## Manual Testing Steps

Manual testing was performed during and after these adjustments were incorporated. Tests involved a run through of the six events with the debugger on to check the `dataObj` & `eventData` as breakpoints were hit:

- 'Viewed Product'
- 'Viewed Category'
- 'Searched Site'
- 'Added to Cart'
- 'Started Checkout'
- 'Order Confirmation'

A Klaviyo Dashboard was checked as well during the above events in both SiteGen & SFRA (Note: data compared using the 'old' / original Klaviyo dashboard view that was active throughout this project).


## Pre-Submission Checklist:
[ x ] This update successfully builds
[ x ] No console errors are displayed on the screen with these updates
[ x ] Console Logs & debugging created during development for debugging that are no longer needed have been removed
[ x ] A description of this update & references to the manual tests has been included in this PR
