### PR TITLE
linter adjustments.

### DIFF
--- a/cartridges/int_klaviyo/cartridge/controllers/Klaviyo.js
+++ b/cartridges/int_klaviyo/cartridge/controllers/Klaviyo.js
@@ -11,7 +11,7 @@ var viewedProductData = require('*/cartridge/scripts/klaviyo/eventData/viewedPro
 var viewedCategoryData = require('*/cartridge/scripts/klaviyo/eventData/viewedCategory');
 var searchedSiteData = require('*/cartridge/scripts/klaviyo/eventData/searchedSite');
 
-var responseUtils = require("*/cartridge/scripts/util/Response");
+var responseUtils = require('*/cartridge/scripts/util/Response');
 
 /**
  * Controller that sends the necessary data required for klaviyo to track user events
@@ -45,6 +45,7 @@ var Event = function () {
                     parms = parms.split('|');
                     dataObj = searchedSiteData.getData(parms[0], parms[1]); // parms: search phrase, result count
                     break;
+                default:
                 }
                 serviceCallResult = klaviyoUtils.trackEvent(exchangeID, dataObj, action, false);
                 if (isKlDebugOn) {

--- a/cartridges/int_klaviyo/cartridge/controllers/KlaviyoRecreate.js
+++ b/cartridges/int_klaviyo/cartridge/controllers/KlaviyoRecreate.js
@@ -9,9 +9,7 @@ var URLUtils = require('dw/web/URLUtils');
 /* Script Modules */
 var app = require('*/cartridge/scripts/app');
 var guard = require('*/cartridge/scripts/guard');
-var cartModel = require('*/cartridge/scripts/models/CartModel');
 var klaviyoCart = require('*/cartridge/scripts/klaviyo/klaviyoATC');
-var res = require("*/cartridge/scripts/util/Response");
 
 
 /**
@@ -31,12 +29,12 @@ function cart() {
 
         app.getView({
             message: Resource.msg('rebuildcart.message.error.general', 'klaviyo_error', null)
-        }).render('klaviyo/klaviyoError')
+        }).render('klaviyo/klaviyoError');
         return;
     }
 
     if (!cart || !items || !items.length) {
-        logger.error(`KlaviyoRecreate-Cart controller failed to create a cart Obj. The currentBasket is ${cart} and items are ${items}.`);
+        // logger.error(`KlaviyoRecreate-Cart controller failed to create a cart Obj. The currentBasket is ${cart} and items are ${items}.`);
 
         app.getView({
             message: Resource.msg('rebuildcart.message.error.general', 'klaviyo_error', null)
@@ -59,13 +57,12 @@ function cart() {
         }).render(renderInfo.template);
     } else if (renderInfo.format === 'ajax') {
         app.getView('Cart', {
-            cart: cart,
-            BonusDiscountLineItem: renderInfo.BonusDiscountLineItem
+            cart                  : cart,
+            BonusDiscountLineItem : renderInfo.BonusDiscountLineItem
         }).render(renderInfo.template);
     } else {
         response.redirect(URLUtils.url('Cart-Show'));
     }
-
 }
 
 

--- a/cartridges/int_klaviyo/cartridge/controllers/KlaviyoRecreate.js
+++ b/cartridges/int_klaviyo/cartridge/controllers/KlaviyoRecreate.js
@@ -34,7 +34,7 @@ function cart() {
     }
 
     if (!cart || !items || !items.length) {
-        // logger.error(`KlaviyoRecreate-Cart controller failed to create a cart Obj. The currentBasket is ${cart} and items are ${items}.`);
+        logger.error(`KlaviyoRecreate-Cart controller failed to create a cart Obj. The currentBasket is ${cart} and items are ${items}.`);
 
         app.getView({
             message: Resource.msg('rebuildcart.message.error.general', 'klaviyo_error', null)

--- a/cartridges/int_klaviyo/cartridge/scripts/klaviyo/klaviyoATC.js
+++ b/cartridges/int_klaviyo/cartridge/scripts/klaviyo/klaviyoATC.js
@@ -38,19 +38,19 @@ function addProductToCart(decodedItems, cartObj) {
         };
     } catch (error) {
         var logger = Logger.getLogger('Klaviyo', 'Klaviyo.SiteGen recreateCartHelpers.js');
-        logger.error('addProductToCart() failed. ERROR at: {0} {1}', error.message, error.stack)
+        logger.error('addProductToCart() failed. ERROR at: {0} {1}', error.message, error.stack);
 
         return {
             success      : false,
             error        : true,
-            errorMessage : `ERROR - Please check the encoded obj for any unexpected chars or syntax issues. ${error.message}`,
+            errorMessage : `ERROR - Please check the encoded obj for any unexpected chars or syntax issues. ${error.message}`
         };
     }
-};
+}
 
 /*
  * Module exports
  */
 module.exports = {
-    addProductToCart: addProductToCart,
-}
+    addProductToCart: addProductToCart
+};

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/eventData/orderConfirmation.js
@@ -299,7 +299,7 @@ function getData(order) {
         data['Item Primary Categories'] = itemPrimaryCategories;
         data['Item Categories'] = klaviyoUtils.dedupeArray(itemCategories);
         data['$value'] = orderTotal;
-        data['$event_id'] = 'orderConfirmation' + '-' + order.orderNo;
+        data['$event_id'] = 'orderConfirmation-' + order.orderNo;
         data['Tracking Number'] = order.shipments[0].trackingNumber ? order.shipments[0].trackingNumber : '';
     } catch (e) {
         var logger = Logger.getLogger('Klaviyo', 'Klaviyo.core orderConfirmation.js');

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/services.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/services.js
@@ -20,16 +20,15 @@ var KlaviyoEventService = ServiceRegistry.createService('KlaviyoEventService', {
    * @returns {String} - A JSON string of the args
    */
     createRequest: function (svc, args) {
-
         var key = Site.getCurrent().getCustomPreferenceValue('klaviyo_api_key');
-        if(!key || key == '') {
+        if (!key || key == '') {
             var logger = Logger.getLogger('Klaviyo', 'Klaviyo.core:  services.js  -  createRequest()');
             logger.error(`KlaviyoEventService failed because of a missing Klaviyo Private API key. Review key & configs for inconsistencies. Klaviyo API Key: ${key}`);
             return;
         }
 
         svc.setRequestMethod('POST');
-        svc.addHeader('Authorization', 'Klaviyo-API-Key '+key);
+        svc.addHeader('Authorization', 'Klaviyo-API-Key ' + key);
         svc.addHeader('Content-type', 'application/json');
         svc.addHeader('Accept', 'application/json');
         svc.addHeader('revision', '2023-02-22');
@@ -66,9 +65,9 @@ var KlaviyoEventService = ServiceRegistry.createService('KlaviyoEventService', {
             };
 
             return JSON.stringify(r);
-        } catch(e) {
+        } catch (e) {
             var err = 'failure to generate full response log object in KlaviyoEventService.getResponseLogMessage()';
-            if(response && response.statusCode) {
+            if (response && response.statusCode) {
                 err += ', statusCode: ' + response.statusCode;
             }
 

--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -24,7 +24,7 @@ var EVENT_NAMES = {
     this site that did not label ATC events as "Added To Cart" there will be a break in reporting and functionality between past events that were not
     labelled with "Add To Cart" and the new events that are labelled "Added To Cart".  If in doubt, leave the site preference set to No and contact Klaviyo technical support.
 */
-if(Site.getCurrent().getCustomPreferenceValue('klaviyo_atc_override')) {
+if (Site.getCurrent().getCustomPreferenceValue('klaviyo_atc_override')) {
     EVENT_NAMES.addedToCart = 'Add To Cart';
 }
 

--- a/cartridges/int_klaviyo_sfra/cartridge/controllers/Cart.js
+++ b/cartridges/int_klaviyo_sfra/cartridge/controllers/Cart.js
@@ -25,7 +25,7 @@ server.append('AddProduct', function (req, res, next) {
         var dataObj;
         var serviceCallResult;
         var currentBasket;
-        var isKlDebugOn = request.getHttpReferer().includes('kldebug=true') ? true : false;
+        var isKlDebugOn = request.getHttpReferer().includes('kldebug=true');
 
         if (exchangeID) {
             currentBasket = BasketMgr.getCurrentBasket();

--- a/cartridges/int_klaviyo_sfra/cartridge/controllers/Klaviyo.js
+++ b/cartridges/int_klaviyo_sfra/cartridge/controllers/Klaviyo.js
@@ -48,6 +48,7 @@ server.get('Event', function (req, res, next) {
                     parms = parms.split('|');
                     dataObj = searchedSiteData.getData(parms[0], parms[1]); // parms: search phrase, result count
                     break;
+                default:
                 }
                 serviceCallResult = klaviyoUtils.trackEvent(exchangeID, dataObj, action, false);
                 if (isKlDebugOn) {

--- a/cartridges/int_klaviyo_sfra/cartridge/controllers/KlaviyoRecreate.js
+++ b/cartridges/int_klaviyo_sfra/cartridge/controllers/KlaviyoRecreate.js
@@ -6,11 +6,9 @@ var server = require('server');
 var BasketMgr = require('dw/order/BasketMgr');
 var Logger = require('dw/system/Logger');
 var ProductMgr = require('dw/catalog/ProductMgr');
-var PromotionMgr = require('dw/campaign/PromotionMgr');
 var Resource = require('dw/web/Resource');
 var StringUtils = require('dw/util/StringUtils');
 var Transaction = require('dw/system/Transaction');
-var URLUtils = require('dw/web/URLUtils');
 
 /* Script Modules */
 var shippingHelper = require('*/cartridge/scripts/checkout/shippingHelpers');
@@ -34,25 +32,24 @@ var CartModel = require('*/cartridge/models/cart');
  */
 server.get('Cart', function (req, res, next) {
     var currentBasket = BasketMgr.getCurrentOrNewBasket();
+    var logger = Logger.getLogger('Klaviyo', 'Klaviyo.core KlaviyoRecreate.js');
     try {
         var items = req.querystring.items ? JSON.parse(StringUtils.decodeBase64(req.querystring.items)) : null;
     } catch (error) {
         res.setStatusCode(500);
-        var logger = Logger.getLogger('Klaviyo', 'Klaviyo.core KlaviyoRecreate.js');
-        logger.error('KlaviyoRecreate-Cart failed. Please check the encoded obj for unexpected chars or syntax issues. ERROR: {0} {1}', error.message, error.stack)
+        logger.error('KlaviyoRecreate-Cart failed. Please check the encoded obj for unexpected chars or syntax issues. ERROR: {0} {1}', error.message, error.stack);
 
         res.render('error', {
-            error: true,
-            message: Resource.msg('rebuildcart.message.error.general', 'klaviyo_error', null)
+            error   : true,
+            message : Resource.msg('rebuildcart.message.error.general', 'klaviyo_error', null)
         });
         return next();
     }
 
     if (!currentBasket) {
         res.setStatusCode(500);
-        var logger = Logger.getLogger('Klaviyo', 'Klaviyo.core KlaviyoRecreate.js');
         logger.error(`KlaviyoRecreate-Cart controller failed to create a cart Obj. The currentBasket is ${currentBasket}.`);
-    };
+    }
 
     // Clean the basket to prevent product duplication on page refresh
     if (currentBasket && currentBasket.productQuantityTotal > 0) {
@@ -67,13 +64,13 @@ server.get('Cart', function (req, res, next) {
                     if (!productToAdd) {
                         throw new Error('Product with ID [' + items[i].productID + '] not found');
                     }
-                    var childProducts = productToAdd.bundledProducts ? collections.map(productToAdd.bundledProducts, function (product) { return { pid: product.ID, quantity: null } }) : [];
+                    var childProducts = productToAdd.bundledProducts ? collections.map(productToAdd.bundledProducts, function (product) { return { pid: product.ID, quantity: null }; }) : [];
                     var options = [];
                     items[i].options.forEach(optionObj => {
                         options.push({ lineItemText: optionObj['Line Item Text'], optionId: optionObj['Option ID'], selectedValueId: optionObj['Option Value ID']});
                     })
 
-                    for (let key in currentBasket.shipments) {
+                    for (var key in currentBasket.shipments) {
                         shippingHelper.ensureShipmentHasMethod(currentBasket.shipments[key]);
                     }
                     cartHelpers.addProductToCart(currentBasket, items[i].productID, items[i].quantity, childProducts, options);
@@ -83,12 +80,10 @@ server.get('Cart', function (req, res, next) {
 
             var basketModel = new CartModel(currentBasket);
             res.render('cart/cart', basketModel);
-        })
+        });
     } catch (error) {
-        var testError = error;
         res.setStatusCode(500);
-        var logger = Logger.getLogger('Klaviyo', 'Klaviyo.core KlaviyoRecreate.js');
-        logger.error('Transaction failed in KlaviyoRecreate-Cart controller. ERROR: {0} {1}', error.message, error.stack)
+        logger.error('Transaction failed in KlaviyoRecreate-Cart controller. ERROR: {0} {1}', error.message, error.stack);
 
         res.render('error', {
             error   : true,

--- a/cartridges/int_klaviyo_sfra/cartridge/controllers/Order.js
+++ b/cartridges/int_klaviyo_sfra/cartridge/controllers/Order.js
@@ -18,17 +18,16 @@ server.append('Confirm', function (req, res, next) {
 
         var exchangeID = klaviyoUtils.getKlaviyoExchangeID();
         var dataObj;
-        var serviceCallResult;
         var currentOrder;
 
-        if(req.form.orderID && req.form.orderToken) {
+        if (req.form.orderID && req.form.orderToken) {
             currentOrder = OrderMgr.getOrder(req.form.orderID, req.form.orderToken);
 
             if (currentOrder && currentOrder.customerEmail) {
                 // check to see if the status is new or created
                 if (currentOrder.status == dw.order.Order.ORDER_STATUS_NEW || currentOrder.status == dw.order.Order.ORDER_STATUS_OPEN) {
                     dataObj = orderConfirmationData.getData(currentOrder, exchangeID);
-                    serviceCallResult = klaviyoUtils.trackEvent(exchangeID, dataObj, klaviyoUtils.EVENT_NAMES.orderConfirmation, currentOrder.customerEmail);
+                    klaviyoUtils.trackEvent(exchangeID, dataObj, klaviyoUtils.EVENT_NAMES.orderConfirmation, currentOrder.customerEmail);
                 }
             }
         }


### PR DESCRIPTION
## Description
This PR resolves additional linter errors flagged in the Initial Check-in of new Klaviyo Cartridge PR (https://github.com/klaviyo/SFCC_Klaviyo/pull/25). These adjustments are a continuation of other updates to resolve linter errors in https://github.com/maze-consulting/SFCC_Klaviyo_Maze/pull/41.

## Manual Testing Steps
Manual tests included a run through of the six Klaviyo events:

1. 'Viewed Product'
2. 'Viewed Category'
3. 'Searched Site'
4. 'Added to Cart'
5. 'Started Checkout'
6. 'Order Confirmation'

Data in the Klaviyo Dashboard was checked during the above events in both SiteGen & SFRA. The Cart Rebuilding link & KlaviyoCart-Rebuild controller was also tested following these updates.

## Pre-Submission Checklist:
- [ x ] This update successfully builds
- [ x ] No console errors are displayed on the screen with these updates
- [ x ] A description of this update & references to the manual tests has been included in this PR