### PR TITLE
KSCU-78: Updates per QA / Testing feedback

### DIFF
--- a/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
+++ b/cartridges/int_klaviyo_core/cartridge/scripts/klaviyo/utils.js
@@ -238,41 +238,16 @@ function subscribeUser(email, phone) {
     var data;
     var result;
 
-    if (email && emailListID) {
-        data = {
-            data: {
-                type       : 'profile-subscription-bulk-create-job',
-                attributes : {
-                    list_id       : emailListID,
-                    custom_source : 'Marketing Event',
-                    subscriptions : [{
-                        channels : { email: ['MARKETING'] },
-                        email    : email
-                    }]
-                }
-            }
-        };
-
-        result = klaviyoServices.KlaviyoSubscribeProfilesService.call(data);
-
-        if (result == null) {
-            logger.error('klaviyoServices.KlaviyoSubscribeProfilesService subscribe call for email returned null result');
-        }
-
-        if (!result.ok === true) {
-            logger.error('klaviyoServices.KlaviyoSubscribeProfilesService subscribe call for email error: ' + result.errorMessage);
-        }
-    }
-
-    if (phone && smsListID) {
+    if (smsListID === emailListID && email && phone) {
         data = { data: {
             type       : 'profile-subscription-bulk-create-job',
             attributes : {
                 list_id       : smsListID,
                 custom_source : 'Marketing Event',
                 subscriptions : [{
-                    channels     : { sms: ['MARKETING'] },
-                    phone_number : phone
+                    channels     : { sms: ['MARKETING'], email: ['MARKETING'] },
+                    phone_number : phone,
+                    email        : email
                 }]
             }
         } };
@@ -280,15 +255,64 @@ function subscribeUser(email, phone) {
         result = klaviyoServices.KlaviyoSubscribeProfilesService.call(data);
 
         if (result == null) {
-            logger.error('klaviyoServices.KlaviyoSubscribeProfilesService subscribe call for SMS returned null result');
+            logger.error('klaviyoServices.KlaviyoSubscribeProfilesService subscribe call for email & SMS returned null result');
         }
 
         if (!result.ok === true) {
-            logger.error('klaviyoServices.KlaviyoSubscribeProfilesService subscribe call for SMS error: ' + result.errorMessage);
+            logger.error('klaviyoServices.KlaviyoSubscribeProfilesService subscribe call for email & SMS error: ' + result.errorMessage);
+        }
+    } else if (smsListID !== emailListID) {
+        if (email && emailListID) {
+            data = {
+                data: {
+                    type       : 'profile-subscription-bulk-create-job',
+                    attributes : {
+                        list_id       : emailListID,
+                        custom_source : 'Marketing Event',
+                        subscriptions : [{
+                            channels : { email: ['MARKETING'] },
+                            email    : email
+                        }]
+                    }
+                }
+            };
+
+            result = klaviyoServices.KlaviyoSubscribeProfilesService.call(data);
+
+            if (result == null) {
+                logger.error('klaviyoServices.KlaviyoSubscribeProfilesService subscribe call for email returned null result');
+            }
+
+            if (!result.ok === true) {
+                logger.error('klaviyoServices.KlaviyoSubscribeProfilesService subscribe call for email error: ' + result.errorMessage);
+            }
+        }
+
+        if (phone && smsListID) {
+            data = { data: {
+                type       : 'profile-subscription-bulk-create-job',
+                attributes : {
+                    list_id       : smsListID,
+                    custom_source : 'Marketing Event',
+                    subscriptions : [{
+                        channels     : { sms: ['MARKETING'] },
+                        phone_number : phone
+                    }]
+                }
+            } };
+
+            result = klaviyoServices.KlaviyoSubscribeProfilesService.call(data);
+
+            if (result == null) {
+                logger.error('klaviyoServices.KlaviyoSubscribeProfilesService subscribe call for SMS returned null result');
+            }
+
+            if (!result.ok === true) {
+                logger.error('klaviyoServices.KlaviyoSubscribeProfilesService subscribe call for SMS error: ' + result.errorMessage);
+            }
         }
     }
 }
-
 
 module.exports = {
     EVENT_NAMES           : EVENT_NAMES,


### PR DESCRIPTION
## Description
This adjustment provides minor updates following QA Testing / feedback. 

This update allows SMS & email to be included in the same subscription call if the same EmailListID & SMSLIstID are used in the site preferences. Linter commands run locally with these updates to confirm linter checks still pass.

## Note
This update is a continuation of an earlier PR in this repo for the same ticket (https://github.com/maze-consulting/SFCC_Klaviyo_Maze/pull/44). This change has been included in the standing PR to the Klaviyo Repo for this feature ([standing PR available here](https://github.com/klaviyo/SFCC_Klaviyo/pull/29))